### PR TITLE
Make state fetching consistent with iOS

### DIFF
--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceExtension.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceExtension.java
@@ -279,10 +279,10 @@ public final class AssuranceExtension extends Extension {
 			// Event Name for XDM shared 		= "Shared state content"
 			// Event Name for Regular  shared 	= "Shared state content (XDM)"
 			if (XDM_SHARED_STATE_CHANGE.equals(event.getName())) {
-				sharedStateResult = getApi().getXDMSharedState(stateOwner, event, true, SharedStateResolution.ANY);
+				sharedStateResult = getApi().getXDMSharedState(stateOwner, event, false, SharedStateResolution.ANY);
 				stateDataKey = XDM_STATE_DATA;
 			} else {
-				sharedStateResult = getApi().getSharedState(stateOwner, event, true, SharedStateResolution.ANY);
+				sharedStateResult = getApi().getSharedState(stateOwner, event, false, SharedStateResolution.ANY);
 				stateDataKey = STATE_DATA;
 			}
 

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceSession.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceSession.java
@@ -168,9 +168,7 @@ class AssuranceSession implements AssuranceWebViewSocketHandler {
 		String orgId = assuranceStateManager.getOrgId(true);
 
 		if (StringUtils.isNullOrEmpty(orgId)) {
-			// Configuration may not have set the state with org id yet.
-			// But this since this is a reconnection usecase, it is OK to send the stored session reconnection url
-			// for fetching org id
+			// if configuration does not have org-id, try extracting it from stored connection url
 			final String reconnectionURL = connectionDataStore.getStoredConnectionURL();
 			if (reconnectionURL == null) {
 				Log.debug(Assurance.LOG_TAG, LOG_TAG, "Cannot connect. No orgId from Configuration state or stored url.");

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceStateManager.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceStateManager.java
@@ -120,7 +120,7 @@ class AssuranceStateManager {
 	 */
 	String getOrgId(final boolean urlEncoded) {
 		final SharedStateResult latestConfigSharedStateResult = extensionApi.getSharedState(
-					AssuranceConstants.SDKSharedStateName.CONFIGURATION, lastSDKEvent, true, SharedStateResolution.ANY);
+					AssuranceConstants.SDKSharedStateName.CONFIGURATION, lastSDKEvent, false, SharedStateResolution.ANY);
 
 		if (!isSharedStateSet(latestConfigSharedStateResult)) {
 			Log.error(Assurance.LOG_TAG, LOG_TAG, "SDK configuration is not available to read OrgId");
@@ -156,7 +156,7 @@ class AssuranceStateManager {
 	List<AssuranceEvent> getAllExtensionStateData() {
 		final List<AssuranceEvent> states = new ArrayList<>();
 		final SharedStateResult eventHubSharedStateResult = extensionApi.getSharedState(
-					AssuranceConstants.SDKSharedStateName.EVENTHUB, lastSDKEvent, true, SharedStateResolution.ANY);
+					AssuranceConstants.SDKSharedStateName.EVENTHUB, lastSDKEvent, false, SharedStateResolution.ANY);
 
 		if (!isSharedStateSet(eventHubSharedStateResult)) {
 			return states;
@@ -203,7 +203,7 @@ class AssuranceStateManager {
 		final List<AssuranceEvent> stateEvents = new ArrayList<>();
 
 		// create an event if the extension has a regular shared state
-		final SharedStateResult regularSharedState = extensionApi.getSharedState(stateOwner, lastSDKEvent, true,
+		final SharedStateResult regularSharedState = extensionApi.getSharedState(stateOwner, lastSDKEvent, false,
 				SharedStateResolution.ANY);
 
 		if (isSharedStateSet(regularSharedState) && !AssuranceUtil.isNullOrEmpty(regularSharedState.getValue())) {
@@ -211,7 +211,7 @@ class AssuranceStateManager {
 		}
 
 		// create an event if the extension has a xdm shared state
-		final SharedStateResult xdmSharedState = extensionApi.getXDMSharedState(stateOwner, lastSDKEvent, true,
+		final SharedStateResult xdmSharedState = extensionApi.getXDMSharedState(stateOwner, lastSDKEvent, false,
 				SharedStateResolution.ANY);
 
 		if (isSharedStateSet(xdmSharedState) && !AssuranceUtil.isNullOrEmpty(xdmSharedState.getValue())) {

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceSessionTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceSessionTest.java
@@ -155,6 +155,32 @@ public class AssuranceSessionTest {
 	}
 
 	@Test
+	public void test_connect_orgIdFromConfigStateUnavailable() throws Exception {
+		when(mockAssuranceStateManager.getOrgId(true)).thenReturn("");
+		when(mockAssuranceConnectionDataStore.getStoredConnectionURL())
+				.thenReturn("wss://connect.griffon.adobe.com/client/v1?" +
+						"sessionId=SampleSessionId&token=1234&orgId=StoredOrg@AdobeOrg&clientId=sampleClientID");
+		PowerMockito.mockStatic(Uri.class);
+		final Uri mockUri = mock(Uri.class);
+		PowerMockito.when(Uri.class, "parse", ArgumentMatchers.anyString()).thenReturn(mockUri);
+		when(mockUri.getQueryParameter("orgId")).thenReturn("StoredOrg@AdobeOrg");
+
+		assuranceSession.connect("1234");
+
+		String expectedURL = String.format(
+				"wss://connect.griffon.adobe.com/client/v1?sessionId=%s&token=%s&orgId=%s&clientId=%s",
+				"SampleSessionID",
+				"1234",
+				"StoredOrg@AdobeOrg",
+				"sampleClientID"
+
+		);
+
+		verify(mockAssuranceSessionPresentationManager).onSessionConnecting();
+		verify(mockAssuranceWebViewSocket).connect(expectedURL);
+	}
+
+	@Test
 	public void test_disconnect() {
 		assuranceSession.disconnect();
 

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceStateManagerTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceStateManagerTest.java
@@ -288,6 +288,6 @@ public class AssuranceStateManagerTest extends TestCase {
 
 		SharedStateResult res = new SharedStateResult(SharedStateStatus.SET, configSharedState);
 		doReturn(res).when(mockApi).getSharedState(AssuranceTestConstants.SDKSharedStateName.CONFIGURATION,
-				null, true, SharedStateResolution.ANY);
+				null, false, SharedStateResolution.ANY);
 	}
 }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Code before 2.0 migration depended on Configuration for fetching reconnection scenario. However with Core 2.0 cofiguration state may not yet be available when Assurance reconnection starts.
- Change the logic to be consistant with iOS and use the ordId from stored URL during reconnection scenarios.
- Change shared state query logic to query with barrier = false to be consistent with iOS

## How Has This Been Tested?
- Unit tests
- Manual test with assurance-testapp

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
