### PR TITLE
Force assemblePhone before publish and fix AAR name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,9 @@ ci-publish-main: clean build-release
 	(./code/gradlew -p code/${EXTENSION-LIBRARY-FOLDER-NAME} publishReleasePublicationToSonatypeRepository -Prelease)
 
 ci-publish-maven-local:
-		(./code/gradlew -p code/${EXTENSION-LIBRARY-FOLDER-NAME} publishReleasePublicationToMavenLocal -x signReleasePublication)
+	(./code/gradlew -p code/${EXTENSION-LIBRARY-FOLDER-NAME} assemblePhone)
+	(./code/gradlew -p code/${EXTENSION-LIBRARY-FOLDER-NAME} publishReleasePublicationToMavenLocal -x signReleasePublication)
 
 ci-publish-jitpack:
-		(./code/gradlew -p code/${EXTENSION-LIBRARY-FOLDER-NAME} publishReleasePublicationToMavenLocal -Pjitpack -x signReleasePublication)
+	(./code/gradlew -p code/${EXTENSION-LIBRARY-FOLDER-NAME} assemblePhone)
+	(./code/gradlew -p code/${EXTENSION-LIBRARY-FOLDER-NAME} publishReleasePublicationToMavenLocal -Pjitpack -x signReleasePublication)

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -20,13 +20,12 @@ org.gradle.configureondemand = false
 
 moduleProjectName=assurance
 moduleName=assurance
-moduleAARName=assurance.aar
+moduleAARName=assurance-phone-release.aar
 moduleVersion=2.0.0
 
 mavenRepoName=AdobeMobileAssurance
 mavenRepoDescription=Android Assurance Extension for Adobe Mobile Marketing
 mavenUploadDryRunFlag=false
 mavenCoreVersion=2.0.0
-functionalTesthelperVersion = 1.0.0-SNAPSHOT
 android.useAndroidX=true
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- The publishToMaven.dependsOn("assemblePhone) is flaky. To ensure successful publish ensure `assemblePhone` is executed before `publishReleasePublicationToMavenLocal`
- Fix the AAR name to be consistent with core.

<!--- Describe your changes in detail -->

## Related Issue
N/A
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The publishToMaven.dependsOn("assemblePhone) is flaky. This is causing jitpack publishing to fail. To ensure successful publish ensure `assemblePhone` is executed before `publishReleasePublicationToMavenLocal`
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Verified locally that the ci-publish-maven-local and ci-publish-jitpack run successfully.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
