### PR TITLE
Do not export internal Assurance activities

### DIFF
--- a/code/assurance/src/main/AndroidManifest.xml
+++ b/code/assurance/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.adobe.marketing.mobile.assurance">
     <application>
-        <activity android:name=".AssuranceFullScreenTakeoverActivity" android:exported="true"/>
-        <activity android:name=".AssuranceErrorDisplayActivity" android:exported="true"/>
+        <activity android:name=".AssuranceFullScreenTakeoverActivity" android:exported="false"/>
+        <activity android:name=".AssuranceErrorDisplayActivity" android:exported="false"/>
     </application>
 </manifest>


### PR DESCRIPTION
`AssuranceFullScreenTakeoverActivity` and `AssuranceErrorDisplayActivity` should only be able to be launched from implementing app context internally. Change the `export` flag to `false` to prevent this activity from being invoked from external contexts.