### PR TITLE
Add NonNull annotations to public API's

### DIFF
--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/Assurance.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/Assurance.java
@@ -12,6 +12,7 @@
 package com.adobe.marketing.mobile;
 
 
+import androidx.annotation.NonNull;
 import com.adobe.marketing.mobile.assurance.AssuranceExtension;
 import com.adobe.marketing.mobile.services.Log;
 import java.util.HashMap;
@@ -37,6 +38,7 @@ public class Assurance {
      *
      * @return A {@link String} representing Assurance extension version
      */
+    @NonNull
     public static String extensionVersion() {
         return EXTENSION_VERSION;
     }
@@ -76,9 +78,9 @@ public class Assurance {
      *
      * @param url a valid Project Assurance deeplink URL to start a session
      */
-    public static void startSession(final String url) {
+    public static void startSession(@NonNull final String url) {
         // validate the obtained URL
-        if (!url.contains(DEEPLINK_SESSION_ID_KEY)) {
+        if (url == null || !url.contains(DEEPLINK_SESSION_ID_KEY)) {
             Log.warning(
                     LOG_TAG,
                     LOG_TAG,
@@ -89,7 +91,7 @@ public class Assurance {
             return;
         }
 
-        final Map<String, Object> startSessionEventData = new HashMap();
+        final Map<String, Object> startSessionEventData = new HashMap<>();
         startSessionEventData.put(START_SESSION_URL, url);
 
         final Event startSessionEvent =

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceTest.java
@@ -41,14 +41,14 @@ public class AssuranceTest {
     }
 
     @Test
-    public void Test_ExtensionVersion() {
+    public void test_ExtensionVersion() {
         // test
         TestCase.assertEquals(
                 AssuranceTestConstants.EXTENSION_VERSION, Assurance.extensionVersion());
     }
 
     @Test
-    public void Test_StartSession() {
+    public void test_StartSession() {
         // prepare
         final String validSessionURL =
                 "assurance://?adb_validation_sessionid=de2ec9c3-9664-4c80-9ec0-bed891dc9471";
@@ -72,7 +72,7 @@ public class AssuranceTest {
     }
 
     @Test
-    public void Test_StartSession_InvalidUrl() {
+    public void test_StartSession_InvalidUrl() {
         // test
         Assurance.startSession("Invalid");
 
@@ -82,7 +82,17 @@ public class AssuranceTest {
     }
 
     @Test
-    public void Test_RegisterExtension() {
+    public void test_StartSession_NullUrl() {
+        // test
+        Assurance.startSession(null);
+
+        // verify
+        PowerMockito.verifyStatic(MobileCore.class, Mockito.times(0));
+        MobileCore.dispatchEvent(any(Event.class));
+    }
+
+    @Test
+    public void test_RegisterExtension() {
         // prepare
         final ArgumentCaptor<ExtensionErrorCallback> extensionErrorCallbackCaptor =
                 ArgumentCaptor.forClass(ExtensionErrorCallback.class);

--- a/code/codeformat.gradle
+++ b/code/codeformat.gradle
@@ -6,7 +6,6 @@ spotless {
         importOrder()
         removeUnusedImports()
         endWithNewline()
-        formatAnnotations()
     }
     kotlin {
         target "src/*/java/**/*.kt"


### PR DESCRIPTION
- Add NonNull annotations to public API's
- Remove `formatAnnotations()` from spotless as it is behaving unexpectedly with NonNull (moves NonNull method annotations to same line i.e `@NonNull public static String extensionVersion() { }` )
- Add a test for null check in public API

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.