### PR TITLE
Add ConstraintLayout POM dependency and fix style name

### DIFF
--- a/code/assurance/build.gradle
+++ b/code/assurance/build.gradle
@@ -166,6 +166,11 @@ publishing {
                     coreDependencyNode.appendNode('groupId', 'com.adobe.marketing.mobile')
                     coreDependencyNode.appendNode('artifactId', 'core')
                     coreDependencyNode.appendNode('version', mavenCoreVersion)
+
+                    def constraintLayoutDependencyNode = dependenciesNode.appendNode('dependency')
+                    constraintLayoutDependencyNode.appendNode('groupId', 'androidx.constraintlayout')
+                    constraintLayoutDependencyNode.appendNode('artifactId', 'constraintlayout')
+                    constraintLayoutDependencyNode.appendNode('version', "1.1.3")
                 }
             }
         }

--- a/code/assurance/src/main/res/values/styles.xml
+++ b/code/assurance/src/main/res/values/styles.xml
@@ -12,7 +12,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AssuranceAppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>


### PR DESCRIPTION
- Assurance has UI components that use constraint layout. Add this as a dependency in POM so that the implementing app is not forced to add this in their gradle if they do not need it.
- Prefix the style name for app theme with Assurance