### PR TITLE
Prepare for 2.0.0 release

### DIFF
--- a/code/assurance-testapp/build.gradle
+++ b/code/assurance-testapp/build.gradle
@@ -69,18 +69,10 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:2.5.1"
 
-    // implementation 'com.adobe.marketing.mobile:assurance:2.0.0'
     implementation project(':assurance')
-    implementation 'com.adobe.marketing.mobile:core:2.0.0-SNAPSHOT'
-    implementation("com.adobe.marketing.mobile:signal:2.0.0-SNAPSHOT") {
-        transitive = false
-    }
-    implementation("com.adobe.marketing.mobile:places:2.0.0-SNAPSHOT") {
-        transitive = false
-    }
-    implementation("com.adobe.marketing.mobile:lifecycle:2.0.0-SNAPSHOT") {
-        transitive = false
-    }
+    implementation 'com.adobe.marketing.mobile:core:2.0.0'
+    implementation 'com.adobe.marketing.mobile:signal:2.0.0'
+    implementation 'com.adobe.marketing.mobile:lifecycle:2.0.0'
 
     //noinspection GradleCompatible
     testImplementation 'junit:junit:4.12'

--- a/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/AssuranceTestApp.kt
+++ b/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/AssuranceTestApp.kt
@@ -17,7 +17,6 @@ import com.adobe.marketing.mobile.Assurance
 import com.adobe.marketing.mobile.Lifecycle
 import com.adobe.marketing.mobile.LoggingMode
 import com.adobe.marketing.mobile.MobileCore
-import com.adobe.marketing.mobile.Places
 import com.adobe.marketing.mobile.Signal
 import com.adobe.marketing.mobile.assurance.testapp.AssuranceTestAppConstants.TAG
 
@@ -37,7 +36,6 @@ class AssuranceTestApp : Application() {
         MobileCore.registerExtensions(
             listOf(
                 Assurance.EXTENSION,
-                Places.EXTENSION,
                 Lifecycle.EXTENSION,
                 Signal.EXTENSION
             )

--- a/code/assurance/build.gradle
+++ b/code/assurance/build.gradle
@@ -237,8 +237,7 @@ task platformFunctionalTestJacocoReport(type: JacocoReport, dependsOn: "createPh
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    //implementation "com.adobe.marketing.mobile:core:${rootProject.mavenCoreVersion}"
-    implementation 'com.adobe.marketing.mobile:core:2.0.0-SNAPSHOT'
+    implementation "com.adobe.marketing.mobile:core:${rootProject.mavenCoreVersion}"
 
     testImplementation 'junit:junit:4.13'
     testImplementation 'com.google.code.gson:gson:2.8.5'

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/Assurance.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/Assurance.java
@@ -16,6 +16,7 @@ import androidx.annotation.NonNull;
 import com.adobe.marketing.mobile.assurance.AssuranceExtension;
 import com.adobe.marketing.mobile.services.Log;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class Assurance {
@@ -44,12 +45,12 @@ public class Assurance {
     }
 
     /**
-     * Register Assurance extension with {@code MobileCore}
+     * Register Assurance extension with the Mobile SDK. This method should be called only once in
+     * you application class.
      *
-     * <p>This will allow the extension to send and receive events to and from the {@code
-     * MobileCore}.
-     *
-     * @return returns an boolean as a result of the Assurance extension registration.
+     * @return true if Assurance extension registration was successfully triggered, false otherwise.
+     * @deprecated as of 2.0.0, use {@link MobileCore#registerExtensions(List, AdobeCallback)} with
+     *     {@link Assurance#EXTENSION} instead.
      */
     @Deprecated
     public static boolean registerExtension() {
@@ -61,9 +62,7 @@ public class Assurance {
                                 LOG_TAG,
                                 LOG_TAG,
                                 String.format(
-                                        "Assurance registration failed with error %s. For more"
-                                            + " details refer to"
-                                            + " https://aep-sdks.gitbook.io/docs/beta/project-griffon/set-up-project-griffon#register-griffon-with-mobile-core",
+                                        "Assurance registration failed with error %s.",
                                         adbExtensionError.getErrorName()));
                     }
                 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Use 2.0.0 for core dependency libraries
- Remove Places dependency in test app to avoid dependency on SNAPSHOT version. It can be added later at the time of testing.
- Fix deprecated registerExtension() java doc.