### PR TITLE
Remove PowerMock from Assurance

### DIFF
--- a/code/assurance/build.gradle
+++ b/code/assurance/build.gradle
@@ -239,12 +239,8 @@ dependencies {
 
     testImplementation 'junit:junit:4.13'
     testImplementation 'com.google.code.gson:gson:2.8.5'
-    testImplementation 'org.mockito:mockito-core:2.28.2'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.9'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.9'
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.9'
-    testImplementation 'org.powermock:powermock-classloading-xstream:2.0.9'
-    testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.9'
+    testImplementation "org.mockito:mockito-core:4.5.1"
+    testImplementation 'org.mockito:mockito-inline:4.5.1'
     testImplementation 'net.sf.kxml:kxml2:2.3.0@jar'
     testImplementation 'org.json:json:20171018'
     testImplementation 'org.robolectric:robolectric:4.2'

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceExtension.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceExtension.java
@@ -17,6 +17,7 @@ import static com.adobe.marketing.mobile.assurance.AssuranceConstants.PayloadDat
 import static com.adobe.marketing.mobile.assurance.AssuranceConstants.SDKEventName.XDM_SHARED_STATE_CHANGE;
 
 import android.net.Uri;
+import androidx.annotation.VisibleForTesting;
 import com.adobe.marketing.mobile.Assurance;
 import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.EventSource;
@@ -66,27 +67,52 @@ public final class AssuranceExtension extends Extension {
      *     {@code MobileCore}.
      */
     AssuranceExtension(final ExtensionApi extensionApi) {
-        super(extensionApi);
-
-        assuranceStateManager =
-                new AssuranceStateManager(extensionApi, MobileCore.getApplication());
-        assuranceConnectionDataStore =
-                new AssuranceConnectionDataStore(MobileCore.getApplication());
-
-        final List<AssurancePlugin> plugins =
+        this(
+                extensionApi,
+                new AssuranceStateManager(extensionApi, MobileCore.getApplication()),
+                new AssuranceConnectionDataStore(MobileCore.getApplication()),
                 Collections.unmodifiableList(
                         Arrays.asList(
                                 new AssurancePluginLogForwarder(),
                                 new AssurancePluginScreenshot(),
                                 new AssurancePluginConfigSwitcher(),
-                                new AssurancePluginFakeEventGenerator()));
+                                new AssurancePluginFakeEventGenerator())));
+    }
 
-        assuranceSessionOrchestrator =
+    /**
+     * Cascading constructor for facilitating dependency injection of components needed for tests.
+     */
+    @VisibleForTesting
+    AssuranceExtension(
+            final ExtensionApi extensionApi,
+            final AssuranceStateManager assuranceStateManager,
+            final AssuranceConnectionDataStore assuranceConnectionDataStore,
+            final List<AssurancePlugin> plugins) {
+        this(
+                extensionApi,
+                assuranceStateManager,
+                assuranceConnectionDataStore,
                 new AssuranceSessionOrchestrator(
                         MobileCore.getApplication(),
                         assuranceStateManager,
                         plugins,
-                        assuranceConnectionDataStore);
+                        assuranceConnectionDataStore));
+    }
+
+    /**
+     * Cascading constructor for facilitating dependency injection of components needed for tests.
+     */
+    @VisibleForTesting
+    AssuranceExtension(
+            final ExtensionApi extensionApi,
+            final AssuranceStateManager assuranceStateManager,
+            final AssuranceConnectionDataStore assuranceConnectionDataStore,
+            final AssuranceSessionOrchestrator assuranceSessionOrchestrator) {
+        super(extensionApi);
+
+        this.assuranceStateManager = assuranceStateManager;
+        this.assuranceConnectionDataStore = assuranceConnectionDataStore;
+        this.assuranceSessionOrchestrator = assuranceSessionOrchestrator;
     }
 
     // ========================================================================================

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssurancePluginScreenshot.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssurancePluginScreenshot.java
@@ -15,6 +15,7 @@ package com.adobe.marketing.mobile.assurance;
 import android.app.Activity;
 import android.graphics.Bitmap;
 import android.view.View;
+import androidx.annotation.VisibleForTesting;
 import com.adobe.marketing.mobile.Assurance;
 import com.adobe.marketing.mobile.assurance.AssuranceConstants.UILogColorVisibility;
 import com.adobe.marketing.mobile.services.Log;
@@ -167,6 +168,26 @@ class AssurancePluginScreenshot implements AssurancePlugin {
                         }
                     }
                 });
+    }
+
+    /**
+     * Returns the session associated with this plugin.
+     *
+     * @return the {@code AssuranceSession} associated with this plugin.
+     */
+    @VisibleForTesting
+    AssuranceSession getParentSession() {
+        return parentSession;
+    }
+
+    /**
+     * Returns the screenshot listener associated with this plugin.
+     *
+     * @return the {@code CaptureScreenShotListener} for this plugin.
+     */
+    @VisibleForTesting
+    CaptureScreenShotListener getCaptureScreenShotListener() {
+        return listener;
     }
 
     interface CaptureScreenShotListener {

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceBlobTests.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceBlobTests.java
@@ -13,31 +13,27 @@ package com.adobe.marketing.mobile.assurance;
 
 import static junit.framework.TestCase.assertTrue;
 
-import java.io.DataOutputStream;
-import java.net.HttpURLConnection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.MockitoAnnotations;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(DataOutputStream.class)
 public class AssuranceBlobTests {
+    @Mock AssuranceSession mockSession;
+
     private static final String SAMPLE_CONTENT_TYPE = "image/jpeg";
     private static final byte[] SAMPLE_BYTE_ARRAY = "SecretString".getBytes();
     private static final String SAMPLE_SESSION_ID = "sessionId";
-
-    @Mock AssuranceSession mockSession;
-
-    @Mock HttpURLConnection mockConnection;
+    private boolean onSuccessCallbackCalled = false;
+    private String onSuccessBlobId;
+    private boolean onFailureCallbackCalled = false;
 
     @Before
-    public void testSetup() {
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
         Mockito.when(mockSession.getAssuranceEnvironment())
                 .thenReturn(AssuranceConstants.AssuranceEnvironment.PROD);
         Mockito.when(mockSession.getSessionId()).thenReturn(SAMPLE_SESSION_ID);
@@ -67,10 +63,6 @@ public class AssuranceBlobTests {
         // verify
         assertTrue(onFailureCallbackCalled);
     }
-
-    private boolean onSuccessCallbackCalled = false;
-    private String onSuccessBlobId;
-    private boolean onFailureCallbackCalled = false;
 
     private AssuranceBlob.BlobUploadCallback createTestableCallback(final CountDownLatch latch) {
         onSuccessCallbackCalled = false;

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceConnectionStatusUITest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceConnectionStatusUITest.java
@@ -11,44 +11,42 @@
 
 package com.adobe.marketing.mobile.assurance;
 
+import static com.adobe.marketing.mobile.assurance.AssuranceTestUtils.setInternalState;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Activity;
+import android.net.Uri;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
+import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.reflect.Whitebox;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 28)
-@PowerMockIgnore({"javax.xml.*", "org.robolectric.*", "android.*"})
 public class AssuranceConnectionStatusUITest {
-
-    private AssuranceConnectionStatusUI connectionStatusUI;
-
-    private Activity mockActivity;
-    private AssuranceFullScreenTakeover mockStatusTakeOver;
     @Mock private AssuranceSessionOrchestrator.ApplicationHandle mockApplicationHandle;
 
     @Mock
     private AssuranceSessionOrchestrator.SessionUIOperationHandler mockSessionUIOperationHandler;
 
+    @Mock private Activity mockActivity;
+
+    private AssuranceConnectionStatusUI connectionStatusUI;
+    @Mock private AssuranceFullScreenTakeover mockStatusTakeOver;
+
+    private MockedStatic<Uri> mockedStaticUri;
+
     @Before
     public void setup() {
-        MockitoAnnotations.initMocks(this);
-        mockActivity = Mockito.mock(Activity.class);
-        mockStatusTakeOver = Mockito.mock(AssuranceFullScreenTakeover.class);
-
+        MockitoAnnotations.openMocks(this);
         when(mockApplicationHandle.getCurrentActivity()).thenReturn(mockActivity);
         connectionStatusUI =
                 new AssuranceConnectionStatusUI(
@@ -156,6 +154,6 @@ public class AssuranceConnectionStatusUITest {
             e.printStackTrace();
         }
 
-        Whitebox.setInternalState(connectionStatusUI, "statusTakeover", mockStatusTakeOver);
+        setInternalState(connectionStatusUI, "statusTakeover", mockStatusTakeOver);
     }
 }

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceIOUtilTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceIOUtilTest.java
@@ -21,12 +21,9 @@ import java.io.StringReader;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.kxml2.io.KXmlParser;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.xmlpull.v1.XmlPullParser;
 
-@RunWith(MockitoJUnitRunner.class)
 public class AssuranceIOUtilTest {
 
     @Test
@@ -40,10 +37,10 @@ public class AssuranceIOUtilTest {
         try {
             xmlPullParser.setInput(reader);
             final JSONObject jsonObj = AssuranceIOUtils.convertXMLToJSON(xmlPullParser);
-            Assert.assertTrue(
+            Assert.assertEquals(
                     new JSONObject(readResourceFile("AndroidManifest_Test.json").replace("\n", ""))
-                            .toString()
-                            .equals(jsonObj.toString()));
+                            .toString(),
+                    jsonObj.toString());
         } catch (final Exception e) {
             Assert.fail("Exception while converting XML to JSON.");
         } finally {

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssurancePluginFakeEventGeneratorTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssurancePluginFakeEventGeneratorTest.java
@@ -13,32 +13,29 @@ package com.adobe.marketing.mobile.assurance;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 
 import com.adobe.marketing.mobile.Event;
-import com.adobe.marketing.mobile.ExtensionErrorCallback;
 import com.adobe.marketing.mobile.MobileCore;
 import java.util.HashMap;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest(MobileCore.class)
 public class AssurancePluginFakeEventGeneratorTest {
 
     private static final String EVENT_TYPE_FAKE_EVENT_GENERATOR = "fakeEvent";
+    private MockedStatic<MobileCore> mockedStaticMobileCore;
 
     AssurancePluginFakeEventGenerator griffonPluginFakeEventGenerator;
 
     @Before
     public void testSetup() {
         griffonPluginFakeEventGenerator = new AssurancePluginFakeEventGenerator();
-        PowerMockito.mockStatic(MobileCore.class);
+        mockedStaticMobileCore = Mockito.mockStatic(MobileCore.class);
     }
 
     @Test
@@ -69,15 +66,12 @@ public class AssurancePluginFakeEventGeneratorTest {
         AssuranceEvent event =
                 new AssuranceEvent(AssuranceConstants.AssuranceEventType.CONTROL, payload);
         final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
-        final ArgumentCaptor<ExtensionErrorCallback> extensionErrorCallbackArgumentCaptor =
-                ArgumentCaptor.forClass(ExtensionErrorCallback.class);
 
         // test
         griffonPluginFakeEventGenerator.onEventReceived(event);
 
         // verify
-        PowerMockito.verifyStatic(MobileCore.class, Mockito.times(1));
-        MobileCore.dispatchEvent(eventCaptor.capture());
+        mockedStaticMobileCore.verify(() -> MobileCore.dispatchEvent(eventCaptor.capture()));
 
         assertEquals("fakeEventName", eventCaptor.getValue().getName());
         assertEquals("fakeEventType", eventCaptor.getValue().getType());
@@ -89,7 +83,7 @@ public class AssurancePluginFakeEventGeneratorTest {
     @Test
     public void test_onEventReceived_NoEventName() {
         // setup
-        HashMap fakeEventDetails = new HashMap<String, Object>();
+        HashMap<String, Object> fakeEventDetails = new HashMap<String, Object>();
         fakeEventDetails.put("eventType", "fakeEventType");
         fakeEventDetails.put("eventSource", "fakeEventSource");
         fakeEventDetails.put(
@@ -100,7 +94,7 @@ public class AssurancePluginFakeEventGeneratorTest {
                     }
                 });
 
-        HashMap payload = new HashMap<String, Object>();
+        HashMap<String, Object> payload = new HashMap<String, Object>();
         payload.put("type", AssuranceConstants.ControlType.FAKE_EVENT);
         payload.put("detail", fakeEventDetails);
         AssuranceEvent event =
@@ -110,14 +104,13 @@ public class AssurancePluginFakeEventGeneratorTest {
         griffonPluginFakeEventGenerator.onEventReceived(event);
 
         // verify no event dispatched
-        PowerMockito.verifyStatic(MobileCore.class, Mockito.times(0));
-        MobileCore.dispatchEvent(any(Event.class), any(ExtensionErrorCallback.class));
+        mockedStaticMobileCore.verify(() -> MobileCore.dispatchEvent(any(Event.class)), times(0));
     }
 
     @Test
     public void test_onEventReceived_NoEventType() {
         // setup
-        HashMap fakeEventDetails = new HashMap<String, Object>();
+        HashMap<String, Object> fakeEventDetails = new HashMap<String, Object>();
         fakeEventDetails.put("eventName", "fakeEventName");
         fakeEventDetails.put("eventSource", "fakeEventSource");
         fakeEventDetails.put(
@@ -128,7 +121,7 @@ public class AssurancePluginFakeEventGeneratorTest {
                     }
                 });
 
-        HashMap payload = new HashMap<String, Object>();
+        HashMap<String, Object> payload = new HashMap<String, Object>();
         payload.put("type", AssuranceConstants.ControlType.FAKE_EVENT);
         payload.put("detail", fakeEventDetails);
         AssuranceEvent event =
@@ -138,14 +131,13 @@ public class AssurancePluginFakeEventGeneratorTest {
         griffonPluginFakeEventGenerator.onEventReceived(event);
 
         // verify no event dispatched
-        PowerMockito.verifyStatic(MobileCore.class, Mockito.times(0));
-        MobileCore.dispatchEvent(any(Event.class), any(ExtensionErrorCallback.class));
+        mockedStaticMobileCore.verify(() -> MobileCore.dispatchEvent(any(Event.class)), times(0));
     }
 
     @Test
     public void test_onEventReceived_NoEventSource() {
         // setup
-        HashMap fakeEventDetails = new HashMap<String, Object>();
+        HashMap<String, Object> fakeEventDetails = new HashMap<String, Object>();
         fakeEventDetails.put("eventName", "fakeEventName");
         fakeEventDetails.put("eventType", "fakeEventType");
         fakeEventDetails.put(
@@ -156,7 +148,7 @@ public class AssurancePluginFakeEventGeneratorTest {
                     }
                 });
 
-        HashMap payload = new HashMap<String, Object>();
+        HashMap<String, Object> payload = new HashMap<String, Object>();
         payload.put("type", AssuranceConstants.ControlType.FAKE_EVENT);
         payload.put("detail", fakeEventDetails);
         AssuranceEvent event =
@@ -166,14 +158,13 @@ public class AssurancePluginFakeEventGeneratorTest {
         griffonPluginFakeEventGenerator.onEventReceived(event);
 
         // verify no event dispatched
-        PowerMockito.verifyStatic(MobileCore.class, Mockito.times(0));
-        MobileCore.dispatchEvent(any(Event.class), any(ExtensionErrorCallback.class));
+        mockedStaticMobileCore.verify(() -> MobileCore.dispatchEvent(any(Event.class)), times(0));
     }
 
     @Test
     public void test_onEventReceived_GriffonEventWithNoControlDetails() {
         // setup
-        HashMap payload = new HashMap<String, Object>();
+        HashMap<String, Object> payload = new HashMap<String, Object>();
         payload.put("type", AssuranceConstants.ControlType.FAKE_EVENT);
         AssuranceEvent event =
                 new AssuranceEvent(AssuranceConstants.AssuranceEventType.CONTROL, payload);
@@ -182,8 +173,7 @@ public class AssurancePluginFakeEventGeneratorTest {
         griffonPluginFakeEventGenerator.onEventReceived(event);
 
         // verify no event dispatched
-        PowerMockito.verifyStatic(MobileCore.class, Mockito.times(0));
-        MobileCore.dispatchEvent(any(Event.class), any(ExtensionErrorCallback.class));
+        mockedStaticMobileCore.verify(() -> MobileCore.dispatchEvent(any(Event.class)), times(0));
     }
 
     @Test
@@ -192,5 +182,10 @@ public class AssurancePluginFakeEventGeneratorTest {
         griffonPluginFakeEventGenerator.onSessionConnected();
         griffonPluginFakeEventGenerator.onSessionDisconnected(0);
         griffonPluginFakeEventGenerator.onSessionTerminated();
+    }
+
+    @After
+    public void teardown() {
+        mockedStaticMobileCore.close();
     }
 }

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssurancePluginManagerTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssurancePluginManagerTest.java
@@ -12,20 +12,17 @@
 package com.adobe.marketing.mobile.assurance;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
 public class AssurancePluginManagerTest {
     @Mock private AssuranceSession mockAssuranceSession;
     @Mock private AssurancePlugin mockPlugin1;

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceSessionOrchestratorTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceSessionOrchestratorTest.java
@@ -11,14 +11,13 @@
 
 package com.adobe.marketing.mobile.assurance;
 
+import static com.adobe.marketing.mobile.assurance.AssuranceTestUtils.setInternalState;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mock;
 
 import android.app.Application;
-import android.net.Uri;
 import java.util.Collections;
 import java.util.List;
 import org.junit.Assert;
@@ -30,13 +29,11 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Uri.class})
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 28)
 public class AssuranceSessionOrchestratorTest {
 
     @Mock private Application mockApplication;
@@ -55,7 +52,7 @@ public class AssuranceSessionOrchestratorTest {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         assuranceSessionOrchestrator =
                 new AssuranceSessionOrchestrator(
@@ -131,8 +128,22 @@ public class AssuranceSessionOrchestratorTest {
 
     @Test
     public void testTerminateSession() {
-        Whitebox.setInternalState(assuranceSessionOrchestrator, "session", mockAssuranceSession);
+        // prepare
+        when(mockAssuranceSessionCreator.create(
+                        eq("SessionID"),
+                        eq(AssuranceConstants.AssuranceEnvironment.PROD),
+                        eq(assuranceSessionOrchestrator.getSessionUIOperationHandler()),
+                        eq(mockAssuranceStateManager),
+                        eq(mockPluginList),
+                        eq(mockAssuranceConnectionDataStore),
+                        eq(mockApplicationHandle),
+                        ArgumentMatchers.<List<AssuranceEvent>>any()))
+                .thenReturn(mockAssuranceSession);
 
+        assuranceSessionOrchestrator.createSession(
+                "SessionID", AssuranceConstants.AssuranceEnvironment.PROD, "1234");
+
+        // test
         assuranceSessionOrchestrator.terminateSession();
 
         verify(mockAssuranceStateManager).clearAssuranceSharedState();
@@ -152,33 +163,25 @@ public class AssuranceSessionOrchestratorTest {
 
     @Test
     public void testReconnectToStoredSession_BadStoredSessionURL() throws Exception {
-        // wss://connect.griffon.adobe.com/client/v1?sessionId=5ccd5a20-1c00-4d6e-bf77-bbe85bc0c758&token=9004&orgId=972C898555E9F7BC7F000101%40AdobeOrg&clientId=89942ef1-11c2-46fb-bcc7-bb797c84e638
         when(mockAssuranceConnectionDataStore.getStoredConnectionURL()).thenReturn("");
         Assert.assertFalse(assuranceSessionOrchestrator.reconnectToStoredSession());
 
-        PowerMockito.mockStatic(Uri.class);
-        Uri mockUri = mock(Uri.class);
-        PowerMockito.when(Uri.class, "parse", ArgumentMatchers.anyString()).thenReturn(mockUri);
-        when(mockUri.getQueryParameter("sessionId")).thenReturn((null));
-        when(mockUri.getQueryParameter("token")).thenReturn(("1232"));
-        when(mockUri.getQueryParameter("orgId")).thenReturn("sampleOrgId");
-        when(mockUri.getQueryParameter("clientId")).thenReturn(("clientID"));
-
+        final String uriWithoutSessionId =
+                "wss://connect.griffon.adobe.com/client/v1?token=9004&orgId=972C898555E9F7BC7F000101%40AdobeOrg&clientId=89942ef1-11c2-46fb-bcc7-bb797c84e638";
+        when(mockAssuranceConnectionDataStore.getStoredConnectionURL())
+                .thenReturn(uriWithoutSessionId);
         Assert.assertFalse(assuranceSessionOrchestrator.reconnectToStoredSession());
 
-        PowerMockito.when(Uri.class, "parse", ArgumentMatchers.anyString()).thenReturn(mockUri);
-        when(mockUri.getQueryParameter("sessionId")).thenReturn(("sampleSessionID"));
-        when(mockUri.getQueryParameter("token")).thenReturn((null));
-        when(mockUri.getQueryParameter("orgId")).thenReturn("sampleOrgID");
-        when(mockUri.getQueryParameter("clientId")).thenReturn(("sampleClientID"));
-
+        final String uriWithoutToken =
+                "wss://connect.griffon.adobe.com/client/v1?sessionId=5ccd5a20-1c00-4d6e-bf77-bbe85bc0c758&orgId=972C898555E9F7BC7F000101%40AdobeOrg&clientId=89942ef1-11c2-46fb-bcc7-bb797c84e638";
+        when(mockAssuranceConnectionDataStore.getStoredConnectionURL()).thenReturn(uriWithoutToken);
         Assert.assertFalse(assuranceSessionOrchestrator.reconnectToStoredSession());
     }
 
     @Test
     public void testReconnectToStoredSession_HasStoredSessionURL() throws Exception {
-        // wss://connect.griffon.adobe.com/client/v1?sessionId=5ccd5a20-1c00-4d6e-bf77-bbe85bc0c758&token=9004&
-        // orgId=972C898555E9F7BC7F000101%40AdobeOrg&clientId=89942ef1-11c2-46fb-bcc7-bb797c84e638
+        final String connectionUrl =
+                "wss://connect.griffon.adobe.com/client/v1?sessionId=5ccd5a20-1c00-4d6e-bf77-bbe85bc0c758&token=9004&orgId=972C898555E9F7BC7F000101%40AdobeOrg&clientId=89942ef1-11c2-46fb-bcc7-bb797c84e638";
         when(mockAssuranceSessionCreator.create(
                         anyString(),
                         eq(AssuranceConstants.AssuranceEnvironment.PROD),
@@ -189,20 +192,12 @@ public class AssuranceSessionOrchestratorTest {
                         eq(mockApplicationHandle),
                         ArgumentMatchers.<List<AssuranceEvent>>any()))
                 .thenReturn(mockAssuranceSession);
-        when(mockAssuranceConnectionDataStore.getStoredConnectionURL())
-                .thenReturn(buildURL("SampleSessionID", "1234", "SampleOrg", "SampleClientID"));
-        PowerMockito.mockStatic(Uri.class);
-        Uri mockUri = mock(Uri.class);
-        PowerMockito.when(Uri.class, "parse", ArgumentMatchers.anyString()).thenReturn(mockUri);
-        when(mockUri.getQueryParameter("sessionId")).thenReturn(("SampleSessionID"));
-        when(mockUri.getQueryParameter("token")).thenReturn(("1234"));
-        when(mockUri.getQueryParameter("orgId")).thenReturn("sampleOrg");
-        when(mockUri.getQueryParameter("clientId")).thenReturn(("SampleClientID"));
+        when(mockAssuranceConnectionDataStore.getStoredConnectionURL()).thenReturn(connectionUrl);
 
         Assert.assertTrue(assuranceSessionOrchestrator.reconnectToStoredSession());
         verify(mockAssuranceSessionCreator)
                 .create(
-                        eq("SampleSessionID"),
+                        eq("5ccd5a20-1c00-4d6e-bf77-bbe85bc0c758"),
                         eq(AssuranceConstants.AssuranceEnvironment.PROD),
                         eq(assuranceSessionOrchestrator.getSessionUIOperationHandler()),
                         eq(mockAssuranceStateManager),
@@ -215,7 +210,7 @@ public class AssuranceSessionOrchestratorTest {
     @Test
     public void testQueueEvent_SessionNotEstablished() {
         final List<AssuranceEvent> mockBuffer = Mockito.mock(List.class);
-        Whitebox.setInternalState(assuranceSessionOrchestrator, "outboundEventBuffer", mockBuffer);
+        setInternalState(assuranceSessionOrchestrator, "outboundEventBuffer", mockBuffer);
 
         AssuranceEvent event = new AssuranceEvent("EventName", Collections.EMPTY_MAP);
         assuranceSessionOrchestrator.queueEvent(event);
@@ -226,8 +221,8 @@ public class AssuranceSessionOrchestratorTest {
     @Test
     public void testQueueEvent_SessionEstablished_NotConnected() {
         final List<AssuranceEvent> mockBuffer = Mockito.mock(List.class);
-        Whitebox.setInternalState(assuranceSessionOrchestrator, "outboundEventBuffer", mockBuffer);
-        Whitebox.setInternalState(assuranceSessionOrchestrator, "session", mockAssuranceSession);
+        setInternalState(assuranceSessionOrchestrator, "outboundEventBuffer", mockBuffer);
+        setInternalState(assuranceSessionOrchestrator, "session", mockAssuranceSession);
 
         AssuranceEvent event = new AssuranceEvent("EventName", Collections.EMPTY_MAP);
         assuranceSessionOrchestrator.queueEvent(event);
@@ -238,28 +233,26 @@ public class AssuranceSessionOrchestratorTest {
 
     @Test
     public void testCanProcessSDKEvents() {
-        Whitebox.setInternalState(
-                assuranceSessionOrchestrator, "outboundEventBuffer", (Object[]) null);
-        Whitebox.setInternalState(assuranceSessionOrchestrator, "session", (Object[]) null);
+        setInternalState(assuranceSessionOrchestrator, "outboundEventBuffer", (Object[]) null);
+        setInternalState(assuranceSessionOrchestrator, "session", (Object[]) null);
         Assert.assertFalse(assuranceSessionOrchestrator.canProcessSDKEvents());
 
         final List<AssuranceEvent> mockBuffer = Mockito.mock(List.class);
-        Whitebox.setInternalState(assuranceSessionOrchestrator, "outboundEventBuffer", mockBuffer);
+        setInternalState(assuranceSessionOrchestrator, "outboundEventBuffer", mockBuffer);
         Assert.assertTrue(assuranceSessionOrchestrator.canProcessSDKEvents());
 
-        Whitebox.setInternalState(
-                assuranceSessionOrchestrator, "outboundEventBuffer", (Object[]) null);
-        Whitebox.setInternalState(assuranceSessionOrchestrator, "session", mockAssuranceSession);
+        setInternalState(assuranceSessionOrchestrator, "outboundEventBuffer", (Object[]) null);
+        setInternalState(assuranceSessionOrchestrator, "session", mockAssuranceSession);
         Assert.assertTrue(assuranceSessionOrchestrator.canProcessSDKEvents());
 
-        Whitebox.setInternalState(assuranceSessionOrchestrator, "outboundEventBuffer", mockBuffer);
-        Whitebox.setInternalState(assuranceSessionOrchestrator, "session", mockAssuranceSession);
+        setInternalState(assuranceSessionOrchestrator, "outboundEventBuffer", mockBuffer);
+        setInternalState(assuranceSessionOrchestrator, "session", mockAssuranceSession);
         Assert.assertTrue(assuranceSessionOrchestrator.canProcessSDKEvents());
     }
 
     @Test
     public void testSessionUIOperationHandler_OnConnect() {
-        Whitebox.setInternalState(assuranceSessionOrchestrator, "session", mockAssuranceSession);
+        setInternalState(assuranceSessionOrchestrator, "session", mockAssuranceSession);
 
         AssuranceSessionOrchestrator.SessionUIOperationHandler sessionUIOperationHandler =
                 assuranceSessionOrchestrator.getSessionUIOperationHandler();
@@ -272,7 +265,7 @@ public class AssuranceSessionOrchestratorTest {
 
     @Test
     public void testSessionUIOperationHandler_OnDisconnect() {
-        Whitebox.setInternalState(assuranceSessionOrchestrator, "session", mockAssuranceSession);
+        setInternalState(assuranceSessionOrchestrator, "session", mockAssuranceSession);
         AssuranceSessionOrchestrator.SessionUIOperationHandler sessionUIOperationHandler =
                 assuranceSessionOrchestrator.getSessionUIOperationHandler();
         Assert.assertNotNull(sessionUIOperationHandler);
@@ -284,16 +277,5 @@ public class AssuranceSessionOrchestratorTest {
                         assuranceSessionOrchestrator.getAssuranceSessionStatusListener());
         verify(mockAssuranceSession).disconnect();
         Assert.assertNull(assuranceSessionOrchestrator.getActiveSession());
-    }
-
-    private String buildURL(
-            final String sessionID, final String token, final String orgId, final String clientID)
-            throws Exception {
-        return String.format(
-                "wss://connect.griffon.adobe.com/client/v1?sessionId=%s&token=%s&orgId=%s&clientId=%s",
-                (sessionID == null ? "" : sessionID),
-                (token == null ? "" : token),
-                (orgId == null ? "" : orgId),
-                (clientID == null ? "" : clientID));
     }
 }

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceSessionPresentationManagerTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceSessionPresentationManagerTest.java
@@ -11,6 +11,7 @@
 
 package com.adobe.marketing.mobile.assurance;
 
+import static com.adobe.marketing.mobile.assurance.AssuranceTestUtils.setInternalState;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -24,14 +25,10 @@ import android.content.Intent;
 import junit.framework.TestCase;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.powermock.reflect.Whitebox;
 
-@RunWith(PowerMockRunner.class)
 public class AssuranceSessionPresentationManagerTest extends TestCase {
 
     private AssuranceSessionPresentationManager assuranceSessionPresentationManager;
@@ -51,18 +48,17 @@ public class AssuranceSessionPresentationManagerTest extends TestCase {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         assuranceSessionPresentationManager =
                 new AssuranceSessionPresentationManager(
                         mockAssuranceStateManager,
                         mockSessionUIOperationHandler,
                         mockApplicationHandle);
-        Whitebox.setInternalState(
+        setInternalState(
                 assuranceSessionPresentationManager, "button", mockAssuranceFloatingButton);
-        Whitebox.setInternalState(
-                assuranceSessionPresentationManager, "statusUI", mockConnectionStatusUI);
-        Whitebox.setInternalState(
+        setInternalState(assuranceSessionPresentationManager, "statusUI", mockConnectionStatusUI);
+        setInternalState(
                 assuranceSessionPresentationManager, "urlProvider", mockPinCodeEntryURLProvider);
     }
 

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceSharedStateTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceSharedStateTest.java
@@ -19,19 +19,13 @@ import static org.mockito.Mockito.when;
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
-import com.adobe.marketing.mobile.MobileCore;
 import java.util.Map;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({Context.class, MobileCore.class})
 public class AssuranceSharedStateTest {
 
     private AssuranceStateManager.AssuranceSharedState assuranceSharedState;

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceStateManagerTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceStateManagerTest.java
@@ -38,15 +38,12 @@ import java.util.List;
 import java.util.Map;
 import junit.framework.TestCase;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
 public class AssuranceStateManagerTest extends TestCase {
 
     @Mock private ExtensionApi mockApi;
@@ -59,11 +56,11 @@ public class AssuranceStateManagerTest extends TestCase {
 
     private AssuranceStateManager assuranceStateManager;
 
-    private Map SAMPLE_STATE_DATA;
-    private Map SAMPLE_XDM_STATE_DATA;
+    private Map<String, Object> SAMPLE_STATE_DATA;
+    private Map<String, Object> SAMPLE_XDM_STATE_DATA;
 
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         SAMPLE_STATE_DATA = new HashMap<String, Object>();
         SAMPLE_STATE_DATA.put("stateKey", "stateValue");

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceTest.java
@@ -13,6 +13,8 @@ package com.adobe.marketing.mobile.assurance;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 
 import com.adobe.marketing.mobile.Assurance;
 import com.adobe.marketing.mobile.Event;
@@ -22,22 +24,20 @@ import com.adobe.marketing.mobile.ExtensionError;
 import com.adobe.marketing.mobile.ExtensionErrorCallback;
 import com.adobe.marketing.mobile.MobileCore;
 import junit.framework.TestCase;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({MobileCore.class})
 public class AssuranceTest {
+
+    private MockedStatic<MobileCore> mockedStaticMobileCore;
 
     @Before
     public void setup() {
-        PowerMockito.mockStatic(MobileCore.class);
+        mockedStaticMobileCore = Mockito.mockStatic(MobileCore.class);
     }
 
     @Test
@@ -58,8 +58,9 @@ public class AssuranceTest {
         Assurance.startSession(validSessionURL);
 
         // verify
-        PowerMockito.verifyStatic(MobileCore.class, Mockito.times(1));
-        MobileCore.dispatchEvent(dispatchedEventCaptor.capture());
+        mockedStaticMobileCore.verify(
+                () -> MobileCore.dispatchEvent(dispatchedEventCaptor.capture()), times(1));
+        // MobileCore.dispatchEvent(dispatchedEventCaptor.capture());
         final Event dispatchedEvent = dispatchedEventCaptor.getValue();
         TestCase.assertEquals(EventType.ASSURANCE, dispatchedEvent.getType());
         TestCase.assertEquals(EventSource.REQUEST_CONTENT, dispatchedEvent.getSource());
@@ -77,8 +78,7 @@ public class AssuranceTest {
         Assurance.startSession("Invalid");
 
         // verify
-        PowerMockito.verifyStatic(MobileCore.class, Mockito.times(0));
-        MobileCore.dispatchEvent(any(Event.class));
+        mockedStaticMobileCore.verify(() -> MobileCore.dispatchEvent(any(Event.class)), times(0));
     }
 
     @Test
@@ -87,8 +87,7 @@ public class AssuranceTest {
         Assurance.startSession(null);
 
         // verify
-        PowerMockito.verifyStatic(MobileCore.class, Mockito.times(0));
-        MobileCore.dispatchEvent(any(Event.class));
+        mockedStaticMobileCore.verify(() -> MobileCore.dispatchEvent(any(Event.class)), times(0));
     }
 
     @Test
@@ -101,10 +100,19 @@ public class AssuranceTest {
         Assurance.registerExtension();
 
         // verify
-        PowerMockito.verifyStatic(MobileCore.class, Mockito.times(1));
-        MobileCore.registerExtension(any(Class.class), extensionErrorCallbackCaptor.capture());
+        mockedStaticMobileCore.verify(
+                () ->
+                        MobileCore.registerExtension(
+                                eq(AssuranceExtension.class),
+                                extensionErrorCallbackCaptor.capture()),
+                times(1));
 
         // test 2 - ErrorCallback is handled without crashing
         extensionErrorCallbackCaptor.getValue().error(ExtensionError.UNEXPECTED_ERROR);
+    }
+
+    @After
+    public void teardown() {
+        mockedStaticMobileCore.close();
     }
 }

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceTestUtils.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceTestUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.assurance;
+
+import static org.junit.Assert.fail;
+
+import java.lang.reflect.Field;
+
+/** Utility class for tests. */
+class AssuranceTestUtils {
+
+    /**
+     * Sets a private field using reflection. Used for setting states of classes where dependency
+     * injection is not trivial.
+     *
+     * @param classToSet the class whose member should be set
+     * @param name the name of the member that should be set
+     * @param value the value of the memberto be set
+     */
+    static void setInternalState(Object classToSet, String name, Object value) {
+        try {
+            final Field privateField = classToSet.getClass().getDeclaredField(name);
+            privateField.setAccessible(true);
+            privateField.set(classToSet, value);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            fail(String.format("Failed to set %s.%s", classToSet, name));
+        }
+    }
+}

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/InboundEventQueueWorkerTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/InboundEventQueueWorkerTest.java
@@ -23,16 +23,13 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
 public class InboundEventQueueWorkerTest {
     @Mock private InboundEventQueueWorker.InboundQueueEventListener mockInboundQueueEventListener;
     @Mock private ExecutorService mockExecutorService;
@@ -40,7 +37,7 @@ public class InboundEventQueueWorkerTest {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
         Mockito.doAnswer(
                         new Answer() {
                             @Override

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/OutboundEventChunkerTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/OutboundEventChunkerTest.java
@@ -26,10 +26,7 @@ import java.util.Map;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
 public class OutboundEventChunkerTest {
 
     @Test

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/OutboundEventQueueWorkerTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/OutboundEventQueueWorkerTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -36,7 +36,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
@@ -44,9 +43,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.powermock.modules.junit4.PowerMockRunner;
 
-@RunWith(PowerMockRunner.class)
 public class OutboundEventQueueWorkerTest {
     @Mock private AssuranceWebViewSocket mockAssuranceWebViewSocket;
     @Mock private ExecutorService mockExecutorService;
@@ -59,7 +56,7 @@ public class OutboundEventQueueWorkerTest {
 
     @Before
     public void setUp() throws Exception {
-        MockitoAnnotations.initMocks(this);
+        MockitoAnnotations.openMocks(this);
 
         Mockito.doAnswer(
                         new Answer() {
@@ -155,7 +152,7 @@ public class OutboundEventQueueWorkerTest {
     @Test
     public void test_offer_workerNotYetStarted() {
         // Simulate the socket connection being open.
-        Mockito.when(mockAssuranceWebViewSocket.getState())
+        when(mockAssuranceWebViewSocket.getState())
                 .thenReturn(AssuranceWebViewSocket.SocketReadyState.OPEN);
         // Simulate the outbound event worker being unblocked.
         outboundEventQueueWorker.unblock();
@@ -174,7 +171,7 @@ public class OutboundEventQueueWorkerTest {
     @Test
     public void test_runnable_eventsSentWhenWorkIsQueued() {
         // Simulate the socket connection being open.
-        Mockito.when(mockAssuranceWebViewSocket.getState())
+        when(mockAssuranceWebViewSocket.getState())
                 .thenReturn(AssuranceWebViewSocket.SocketReadyState.OPEN);
 
         final AssuranceEvent event1 = new AssuranceEvent("type", Collections.EMPTY_MAP);
@@ -212,7 +209,7 @@ public class OutboundEventQueueWorkerTest {
 
     @Test
     public void test_runnable_eventsBlockedWhenCannotStartForwarding() {
-        Mockito.when(mockAssuranceWebViewSocket.getState())
+        when(mockAssuranceWebViewSocket.getState())
                 .thenReturn(AssuranceWebViewSocket.SocketReadyState.OPEN);
 
         final AssuranceEvent event1 = new AssuranceEvent("type", Collections.EMPTY_MAP);
@@ -247,7 +244,7 @@ public class OutboundEventQueueWorkerTest {
 
     @Test
     public void test_runnable_eventsBlockedWhenSocketNotConnected() {
-        Mockito.when(mockAssuranceWebViewSocket.getState())
+        when(mockAssuranceWebViewSocket.getState())
                 .thenReturn(AssuranceWebViewSocket.SocketReadyState.OPEN);
 
         final AssuranceEvent event1 = new AssuranceEvent("type", Collections.EMPTY_MAP);
@@ -256,7 +253,7 @@ public class OutboundEventQueueWorkerTest {
 
         outboundEventQueueWorker.start();
         // Simulate socket disconnection.
-        Mockito.when(mockAssuranceWebViewSocket.getState())
+        when(mockAssuranceWebViewSocket.getState())
                 .thenReturn(AssuranceWebViewSocket.SocketReadyState.CLOSED);
         outboundEventQueueWorker.offer(event1);
         outboundEventQueueWorker.offer(event2);
@@ -301,7 +298,7 @@ public class OutboundEventQueueWorkerTest {
 
     @Test
     public void test_sendEvent_payloadOverMaxPayloadSize_20KB() {
-        Mockito.when(mockAssuranceWebViewSocket.getState())
+        when(mockAssuranceWebViewSocket.getState())
                 .thenReturn(AssuranceWebViewSocket.SocketReadyState.OPEN);
 
         try {
@@ -341,7 +338,7 @@ public class OutboundEventQueueWorkerTest {
 
     @Test
     public void test_sendEvent_payloadOverMaxPayloadSize_40KB() {
-        Mockito.when(mockAssuranceWebViewSocket.getState())
+        when(mockAssuranceWebViewSocket.getState())
                 .thenReturn(AssuranceWebViewSocket.SocketReadyState.OPEN);
 
         try {
@@ -416,7 +413,7 @@ public class OutboundEventQueueWorkerTest {
 
     @Test
     public void test_sendEvent_payloadOverMaxPayloadSize_HTML() {
-        Mockito.when(mockAssuranceWebViewSocket.getState())
+        when(mockAssuranceWebViewSocket.getState())
                 .thenReturn(AssuranceWebViewSocket.SocketReadyState.OPEN);
 
         try {

--- a/code/assurance/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/code/assurance/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,5 +1,4 @@
-#
-# Copyright 2022 Adobe. All rights reserved.
+# Copyright 2023 Adobe. All rights reserved.
 # This file is licensed to you under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License. You may obtain a copy
 # of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -7,6 +6,5 @@
 # the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
 # OF ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
-#
 
-mockito.mock-maker-class=mock-maker-inline
+mock-maker-inline


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- Remove PowerMock and use Mockito instead.
- Restructure a few classes to allow dependency injection.
- Mimic `setInternalState` to allow setting mocks for private memebers where injection is not trivial without architecture changes.

<!--- Describe your changes in detail -->

## Related Issue
#10 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Mockito provides most functionality required for testing (static and final mocks) and is no longer required. 
 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Verify unit tests run
- Smoke test on functionality
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.