### PR TITLE
Send appSettings in client info event

### DIFF
--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceClientInfo.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceClientInfo.java
@@ -11,7 +11,6 @@
 
 package com.adobe.marketing.mobile.assurance;
 
-import static android.content.Context.BATTERY_SERVICE;
 
 import android.Manifest;
 import android.app.Application;
@@ -36,6 +35,8 @@ import java.util.Map;
 final class AssuranceClientInfo {
 
     private static final String VALUE_UNKNOWN = "Unknown";
+    private static final String MANIFEST_FILE_NAME = "AndroidManifest.xml";
+    private static final String EVENT_TYPE_CONNECT = "connect";
 
     /**
      * Returns the payload for assurance ClientInfo event. ClientInfo event includes
@@ -51,16 +52,14 @@ final class AssuranceClientInfo {
      *
      * @return Returns {@link Map} representing clientInfo event payload
      */
-    final Map<String, Object> getData() {
-        final Map<String, Object> eventPayload = new HashMap<>(1);
+    Map<String, Object> getData() {
+        final Map<String, Object> eventPayload = new HashMap<>();
         eventPayload.put(AssuranceConstants.ClientInfoKeys.VERSION, Assurance.extensionVersion());
         eventPayload.put(AssuranceConstants.ClientInfoKeys.DEVICE_INFO, getDeviceInfo());
-        eventPayload.put(AssuranceConstants.PayloadDataKeys.TYPE, "connect");
-
-        // TODO : https://jira.corp.adobe.com/browse/AMSDK-10653 send Manifest xml using blob
-        // service
-        // eventPayload.put(AssuranceConstants.ClientInfoKeys.APP_SETTINGS,
-        // AssuranceIOUtils.parseXMLResourceFileToJson("AndroidManifest.xml"));
+        eventPayload.put(AssuranceConstants.PayloadDataKeys.TYPE, EVENT_TYPE_CONNECT);
+        eventPayload.put(
+                AssuranceConstants.ClientInfoKeys.APP_SETTINGS,
+                AssuranceIOUtils.parseXMLResourceFileToJson(MANIFEST_FILE_NAME));
         return eventPayload;
     }
 
@@ -87,16 +86,25 @@ final class AssuranceClientInfo {
      */
     private HashMap<String, Object> getDeviceInfo() {
         final HashMap<String, Object> deviceInfo = new HashMap<>();
-        deviceInfo.put("Canonical platform name", "Android");
-        deviceInfo.put("Device name", Build.MODEL);
-        deviceInfo.put("Device manufacturer", Build.MANUFACTURER);
-        deviceInfo.put("Operating system", "Android " + Build.VERSION.RELEASE);
-        deviceInfo.put("Carrier name", getMobileCarrierName());
-        deviceInfo.put("Battery level ", getBatteryPercentage());
-        deviceInfo.put("Screen size ", getScreenSize());
-        deviceInfo.put("Location service enabled", isLocationEnabled());
-        deviceInfo.put("Location authorization status", getCurrentLocationPermission());
-        deviceInfo.put("Low power mode enabled", isPowerSaveModeEnabled());
+        deviceInfo.put(AssuranceConstants.DeviceInfoKeys.PLATFORM_NAME, "Android");
+        deviceInfo.put(AssuranceConstants.DeviceInfoKeys.DEVICE_NAME, Build.MODEL);
+        deviceInfo.put(AssuranceConstants.DeviceInfoKeys.DEVICE_TYPE, Build.DEVICE);
+        deviceInfo.put(AssuranceConstants.DeviceInfoKeys.DEVICE_MANUFACTURER, Build.MANUFACTURER);
+        deviceInfo.put(
+                AssuranceConstants.DeviceInfoKeys.OPERATING_SYSTEM,
+                "Android " + Build.VERSION.RELEASE);
+        deviceInfo.put(AssuranceConstants.DeviceInfoKeys.CARRIER_NAME, getMobileCarrierName());
+        deviceInfo.put(AssuranceConstants.DeviceInfoKeys.BATTERY_LEVEL, getBatteryPercentage());
+        deviceInfo.put(AssuranceConstants.DeviceInfoKeys.SCREEN_SIZE, getScreenSize());
+        deviceInfo.put(
+                AssuranceConstants.DeviceInfoKeys.LOCATION_SERVICE_ENABLED, isLocationEnabled());
+        deviceInfo.put(
+                AssuranceConstants.DeviceInfoKeys.LOCATION_AUTHORIZATION_STATUS,
+                getCurrentLocationPermission());
+        deviceInfo.put(
+                AssuranceConstants.DeviceInfoKeys.LOW_POWER_BATTERY_ENABLED,
+                isPowerSaveModeEnabled());
+
         return deviceInfo;
     }
 
@@ -136,7 +144,8 @@ final class AssuranceClientInfo {
 
         if (Build.VERSION.SDK_INT >= 21) {
 
-            final BatteryManager bm = (BatteryManager) context.getSystemService(BATTERY_SERVICE);
+            final BatteryManager bm =
+                    (BatteryManager) context.getSystemService(Context.BATTERY_SERVICE);
             return bm.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY);
 
         } else {

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceConstants.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceConstants.java
@@ -158,6 +158,21 @@ final class AssuranceConstants {
         private ClientInfoKeys() {}
     }
 
+    static final class DeviceInfoKeys {
+        static final String PLATFORM_NAME = "Canonical platform name";
+        static final String DEVICE_NAME = "Device name";
+        static final String DEVICE_MANUFACTURER = "Device manufacturer";
+        static final String OPERATING_SYSTEM = "Operating system";
+        static final String CARRIER_NAME = "Carrier name";
+        static final String DEVICE_TYPE = "Device type";
+        static final String MODEL = "Model";
+        static final String SCREEN_SIZE = "Screen size";
+        static final String LOCATION_SERVICE_ENABLED = "Location service enabled";
+        static final String LOCATION_AUTHORIZATION_STATUS = "Location authorization status";
+        static final String LOW_POWER_BATTERY_ENABLED = "Low power mode enabled";
+        static final String BATTERY_LEVEL = "Battery level";
+    }
+
     static final class SocketURLKeys {
         static final String SESSION_ID = "sessionId";
         static final String CLIENT_ID = "clientId";

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceClientInfoTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceClientInfoTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.assurance;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import android.Manifest;
+import android.app.Application;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.location.LocationManager;
+import android.os.BatteryManager;
+import android.os.PowerManager;
+import android.telephony.TelephonyManager;
+import androidx.core.app.ActivityCompat;
+import com.adobe.marketing.mobile.services.AppContextService;
+import com.adobe.marketing.mobile.services.ServiceProvider;
+import java.util.Map;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 28)
+public class AssuranceClientInfoTest {
+    @Mock private AppContextService mockAppContextService;
+
+    @Mock private BatteryManager mockBatteryManager;
+
+    @Mock private LocationManager mockLocationManager;
+
+    @Mock private PowerManager mockPowerManager;
+
+    @Mock private TelephonyManager mockTelephonyManager;
+
+    @Mock private ServiceProvider mockServiceProvider;
+
+    @Mock private Context mockAppContext;
+
+    private AssuranceClientInfo assuranceClientInfo;
+
+    private MockedStatic<AssuranceIOUtils> mockedStaticAssuranceIOUtils;
+    private MockedStatic<ServiceProvider> mockedStaticServiceProvider;
+    private MockedStatic<ActivityCompat> mockedStaticActivityCompat;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+        assuranceClientInfo = new AssuranceClientInfo();
+        mockedStaticActivityCompat = Mockito.mockStatic(ActivityCompat.class);
+        mockedStaticAssuranceIOUtils = Mockito.mockStatic(AssuranceIOUtils.class);
+        mockedStaticServiceProvider = Mockito.mockStatic(ServiceProvider.class);
+    }
+
+    @Test
+    public void testGetData_happy() throws JSONException {
+        final JSONObject appSettings = mockManifestData();
+        mockedStaticAssuranceIOUtils
+                .when(() -> AssuranceIOUtils.parseXMLResourceFileToJson(any()))
+                .thenReturn(appSettings);
+
+        mockAppContextService();
+        mockTelephonyManager("MyNetworkCarrier");
+        mockBatteryLevel(95);
+        mockLocationManager(true, true);
+        mockPowerManager(false);
+
+        final Map<String, Object> data = assuranceClientInfo.getData();
+        assertEquals("2.0.0", data.get(AssuranceConstants.ClientInfoKeys.VERSION));
+        assertEquals("connect", data.get(AssuranceConstants.PayloadDataKeys.TYPE));
+        assertEquals(appSettings, data.get(AssuranceConstants.ClientInfoKeys.APP_SETTINGS));
+
+        final Map<String, Object> obtainedDeviceInfo =
+                (Map<String, Object>) data.get(AssuranceConstants.ClientInfoKeys.DEVICE_INFO);
+        assertNotNull(obtainedDeviceInfo);
+        assertEquals(
+                "MyNetworkCarrier",
+                obtainedDeviceInfo.get(AssuranceConstants.DeviceInfoKeys.CARRIER_NAME));
+        assertEquals(95, obtainedDeviceInfo.get(AssuranceConstants.DeviceInfoKeys.BATTERY_LEVEL));
+        assertEquals(
+                "Always",
+                obtainedDeviceInfo.get(
+                        AssuranceConstants.DeviceInfoKeys.LOCATION_AUTHORIZATION_STATUS));
+        assertEquals(
+                true,
+                obtainedDeviceInfo.get(AssuranceConstants.DeviceInfoKeys.LOCATION_SERVICE_ENABLED));
+        assertEquals(
+                false,
+                obtainedDeviceInfo.get(
+                        AssuranceConstants.DeviceInfoKeys.LOW_POWER_BATTERY_ENABLED));
+    }
+
+    @Test
+    public void testGetData_locationAuthorizationDenied() throws JSONException {
+        final JSONObject appSettings = mockManifestData();
+        mockedStaticAssuranceIOUtils
+                .when(() -> AssuranceIOUtils.parseXMLResourceFileToJson(any()))
+                .thenReturn(appSettings);
+
+        mockAppContextService();
+        mockTelephonyManager("MyNetworkCarrier");
+        mockBatteryLevel(95);
+        mockLocationManager(false, false);
+        mockPowerManager(false);
+
+        final Map<String, Object> data = assuranceClientInfo.getData();
+        assertEquals("2.0.0", data.get(AssuranceConstants.ClientInfoKeys.VERSION));
+        assertEquals("connect", data.get(AssuranceConstants.PayloadDataKeys.TYPE));
+        assertEquals(appSettings, data.get(AssuranceConstants.ClientInfoKeys.APP_SETTINGS));
+
+        final Map<String, Object> obtainedDeviceInfo =
+                (Map<String, Object>) data.get(AssuranceConstants.ClientInfoKeys.DEVICE_INFO);
+        assertNotNull(obtainedDeviceInfo);
+        assertEquals(
+                "MyNetworkCarrier",
+                obtainedDeviceInfo.get(AssuranceConstants.DeviceInfoKeys.CARRIER_NAME));
+        assertEquals(95, obtainedDeviceInfo.get(AssuranceConstants.DeviceInfoKeys.BATTERY_LEVEL));
+        assertEquals(
+                "Denied",
+                obtainedDeviceInfo.get(
+                        AssuranceConstants.DeviceInfoKeys.LOCATION_AUTHORIZATION_STATUS));
+        assertEquals(
+                false,
+                obtainedDeviceInfo.get(AssuranceConstants.DeviceInfoKeys.LOCATION_SERVICE_ENABLED));
+        assertEquals(
+                false,
+                obtainedDeviceInfo.get(
+                        AssuranceConstants.DeviceInfoKeys.LOW_POWER_BATTERY_ENABLED));
+    }
+
+    @Test
+    public void testGetData_lowPowerModeEnabled() throws JSONException {
+        final JSONObject appSettings = mockManifestData();
+        mockedStaticAssuranceIOUtils
+                .when(() -> AssuranceIOUtils.parseXMLResourceFileToJson(any()))
+                .thenReturn(appSettings);
+
+        mockAppContextService();
+        mockTelephonyManager("MyNetworkCarrier");
+        mockBatteryLevel(95);
+        mockLocationManager(false, false);
+        mockPowerManager(true);
+
+        final Map<String, Object> data = assuranceClientInfo.getData();
+        assertEquals("2.0.0", data.get(AssuranceConstants.ClientInfoKeys.VERSION));
+        assertEquals("connect", data.get(AssuranceConstants.PayloadDataKeys.TYPE));
+        assertEquals(appSettings, data.get(AssuranceConstants.ClientInfoKeys.APP_SETTINGS));
+
+        final Map<String, Object> obtainedDeviceInfo =
+                (Map<String, Object>) data.get(AssuranceConstants.ClientInfoKeys.DEVICE_INFO);
+        assertNotNull(obtainedDeviceInfo);
+        assertEquals(
+                "MyNetworkCarrier",
+                obtainedDeviceInfo.get(AssuranceConstants.DeviceInfoKeys.CARRIER_NAME));
+        assertEquals(95, obtainedDeviceInfo.get(AssuranceConstants.DeviceInfoKeys.BATTERY_LEVEL));
+        assertEquals(
+                "Denied",
+                obtainedDeviceInfo.get(
+                        AssuranceConstants.DeviceInfoKeys.LOCATION_AUTHORIZATION_STATUS));
+        assertEquals(
+                false,
+                obtainedDeviceInfo.get(AssuranceConstants.DeviceInfoKeys.LOCATION_SERVICE_ENABLED));
+        assertEquals(
+                true,
+                obtainedDeviceInfo.get(
+                        AssuranceConstants.DeviceInfoKeys.LOW_POWER_BATTERY_ENABLED));
+    }
+
+    @After
+    public void teardown() {
+        mockedStaticServiceProvider.close();
+        mockedStaticActivityCompat.close();
+        mockedStaticAssuranceIOUtils.close();
+    }
+
+    private JSONObject mockManifestData() throws JSONException {
+        final JSONObject appSettings = new JSONObject();
+        final JSONObject manifest = new JSONObject();
+        manifest.put("package", "com.assurance.testapp");
+        appSettings.put("manifest", manifest);
+        appSettings.put("versionCode", "1");
+        appSettings.put("versionName", "1.0");
+        return appSettings;
+    }
+
+    private void mockAppContextService() {
+        mockedStaticServiceProvider
+                .when(ServiceProvider::getInstance)
+                .thenReturn(mockServiceProvider);
+        when(mockServiceProvider.getAppContextService()).thenReturn(mockAppContextService);
+        when(mockAppContextService.getApplicationContext()).thenReturn(mockAppContext);
+    }
+
+    private void mockTelephonyManager(final String carrierName) {
+        when(mockAppContext.getSystemService(Application.TELEPHONY_SERVICE))
+                .thenReturn(mockTelephonyManager);
+        when(mockTelephonyManager.getNetworkOperatorName()).thenReturn(carrierName);
+    }
+
+    private void mockBatteryLevel(int level) {
+        when(mockAppContext.getSystemService(Context.BATTERY_SERVICE))
+                .thenReturn(mockBatteryManager);
+        when(mockBatteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY))
+                .thenReturn(level);
+    }
+
+    private void mockLocationManager(
+            final boolean locationEnabled, final boolean accessFineLocation) {
+        when(mockAppContext.getSystemService(Context.LOCATION_SERVICE))
+                .thenReturn(mockLocationManager);
+        when(mockLocationManager.isLocationEnabled()).thenReturn(locationEnabled);
+
+        mockedStaticActivityCompat
+                .when(
+                        () ->
+                                ActivityCompat.checkSelfPermission(
+                                        mockAppContext, Manifest.permission.ACCESS_FINE_LOCATION))
+                .thenReturn(
+                        accessFineLocation
+                                ? PackageManager.PERMISSION_GRANTED
+                                : PackageManager.PERMISSION_DENIED);
+    }
+
+    private void mockPowerManager(boolean isPowerSaveModeEnabled) {
+        when(mockAppContext.getSystemService(Context.POWER_SERVICE)).thenReturn(mockPowerManager);
+        when(mockPowerManager.isPowerSaveMode()).thenReturn(isPowerSaveModeEnabled);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Assurance Android SDK currently does not send "appSettings" as part of the client info event. This is because of an earlier limitation in the services in handling large payloads for this specific event. Assurance services have now been enhanced to handle large payloads, so it is safe to send the appSettings now.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Assurance Android SDK currently does not send "appSettings" as part of the client info event. This is because of an earlier limitation in the services in handling large payloads for this specific event. Assurance services have now been enhanced to handle large payloads, so it is safe to send the appSettings now.
- Send appSettings
- Switch strings to constants
- Add some unit tests

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
- Unit tests
- Manual smoke testing
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.