### PR TITLE
Unify Assurance error codes

### DIFF
--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssurancePinCodeEntryURLProvider.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssurancePinCodeEntryURLProvider.java
@@ -190,13 +190,13 @@ class AssurancePinCodeEntryURLProvider
     }
 
     public void onConnectionFailed(
-            final AssuranceConstants.AssuranceSocketError socketError,
+            final AssuranceConstants.AssuranceConnectionError connectionError,
             final boolean shouldShowRetry) {
         pinCodeTakeover.runJavascript(
                 "showError('"
-                        + socketError.getError()
+                        + connectionError.getError()
                         + "', '"
-                        + socketError.getErrorDescription()
+                        + connectionError.getDescription()
                         + "', "
                         + shouldShowRetry
                         + ")");
@@ -205,7 +205,7 @@ class AssurancePinCodeEntryURLProvider
                 LOG_TAG,
                 String.format(
                         "Assurance connection closed. Reason: %s, Description: %s",
-                        socketError.getError(), socketError.getErrorDescription()));
+                        connectionError.getError(), connectionError.getDescription()));
     }
 
     @Override
@@ -237,9 +237,10 @@ class AssurancePinCodeEntryURLProvider
                         LOG_TAG,
                         String.format(
                                 "%s %s",
-                                AssuranceConstants.AssuranceSocketError.NO_ORGID.getError(),
-                                AssuranceConstants.AssuranceSocketError.NO_ORGID.getError()));
-                onConnectionFailed(AssuranceConstants.AssuranceSocketError.NO_ORGID, true);
+                                AssuranceConstants.AssuranceConnectionError.NO_ORG_ID.getError(),
+                                AssuranceConstants.AssuranceConnectionError.NO_ORG_ID
+                                        .getDescription()));
+                onConnectionFailed(AssuranceConstants.AssuranceConnectionError.NO_ORG_ID, true);
                 return true;
             }
 

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceSessionOrchestrator.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceSessionOrchestrator.java
@@ -122,7 +122,8 @@ class AssuranceSessionOrchestrator {
                 }
 
                 @Override
-                public void onSessionTerminated() {
+                public void onSessionTerminated(
+                        final AssuranceConstants.AssuranceConnectionError error) {
                     // In case of a user initiated AssuranceSessionOrchestrator#terminateSession()
                     // will unregister the listener against the session
                     // before disconnecting it. So this callback is never invoked in that flow.

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceSessionPresentationManager.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceSessionPresentationManager.java
@@ -101,35 +101,20 @@ class AssuranceSessionPresentationManager {
 
     /** Shows the UI elements that are required when a session connection has been disconnected. */
     void onSessionDisconnected(final int closeCode) {
-        switch (closeCode) {
-            case AssuranceConstants.SocketCloseCode.NORMAL:
-                cleanupUIElements();
-                break;
+        if (closeCode == AssuranceConstants.SocketCloseCode.NORMAL) {
+            cleanupUIElements();
+            return;
+        }
 
-            case AssuranceConstants.SocketCloseCode.ORG_MISMATCH:
-                displayError(AssuranceConstants.AssuranceSocketError.ORGID_MISMATCH, closeCode);
-                break;
+        final AssuranceConstants.AssuranceConnectionError assuranceConnectionError =
+                AssuranceConstants.SocketCloseCode.toAssuranceConnectionError(closeCode);
 
-            case AssuranceConstants.SocketCloseCode.CLIENT_ERROR:
-                displayError(AssuranceConstants.AssuranceSocketError.CLIENT_ERROR, closeCode);
-                break;
-
-            case AssuranceConstants.SocketCloseCode.CONNECTION_LIMIT:
-                displayError(AssuranceConstants.AssuranceSocketError.CONNECTION_LIMIT, closeCode);
-                break;
-
-            case AssuranceConstants.SocketCloseCode.EVENT_LIMIT:
-                displayError(AssuranceConstants.AssuranceSocketError.EVENT_LIMIT, closeCode);
-                break;
-
-            case AssuranceConstants.SocketCloseCode.SESSION_DELETED:
-                displayError(AssuranceConstants.AssuranceSocketError.SESSION_DELETED, closeCode);
-                break;
-
-            default:
-                displayError(
-                        AssuranceConstants.AssuranceSocketError.GENERIC_ERROR,
-                        AssuranceConstants.SocketCloseCode.ABNORMAL);
+        if (assuranceConnectionError != null) {
+            displayError(assuranceConnectionError, closeCode);
+        } else {
+            displayError(
+                    AssuranceConstants.AssuranceConnectionError.GENERIC_ERROR,
+                    AssuranceConstants.SocketCloseCode.ABNORMAL);
         }
     }
 
@@ -224,7 +209,7 @@ class AssuranceSessionPresentationManager {
     }
 
     private void displayError(
-            final AssuranceConstants.AssuranceSocketError socketError, final int closeCode) {
+            final AssuranceConstants.AssuranceConnectionError socketError, final int closeCode) {
         if (urlProvider != null && urlProvider.isDisplayed()) {
             // If this is an unhandled/abnormal error while the PIN screen is on, set the retry flag
             // to true.
@@ -262,7 +247,7 @@ class AssuranceSessionPresentationManager {
         }
     }
 
-    private void showErrorDisplay(final AssuranceConstants.AssuranceSocketError socketError) {
+    private void showErrorDisplay(final AssuranceConstants.AssuranceConnectionError socketError) {
         final Activity currentActivity = applicationHandle.getCurrentActivity();
 
         if (currentActivity == null) {
@@ -282,7 +267,7 @@ class AssuranceSessionPresentationManager {
                     AssuranceConstants.IntentExtraKey.ERROR_NAME, socketError.getError());
             errorScreen.putExtra(
                     AssuranceConstants.IntentExtraKey.ERROR_DESCRIPTION,
-                    socketError.getErrorDescription());
+                    socketError.getDescription());
             currentActivity.startActivity(errorScreen);
             currentActivity.overridePendingTransition(0, 0);
         } catch (final ActivityNotFoundException ex) {

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/QuickConnectCallback.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/QuickConnectCallback.java
@@ -23,10 +23,10 @@ interface QuickConnectCallback {
     /**
      * Invoked when an error occurs when during QuickConnect connection workflow.
      *
-     * @param error an {@code AssuranceQuickConnectError} that occurred resulting in quick connect
+     * @param error an {@code AssuranceConnectionError} that occurred resulting in quick connect
      *     workflow cancellation
      */
-    void onError(@NonNull AssuranceConstants.AssuranceQuickConnectError error);
+    void onError(@NonNull AssuranceConstants.AssuranceConnectionError error);
 
     /**
      * Invoked with the quick connect session details when the QuickConnect workflow is successful.

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/QuickConnectDeviceCreator.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/QuickConnectDeviceCreator.kt
@@ -14,7 +14,7 @@ package com.adobe.marketing.mobile.assurance
 import androidx.annotation.VisibleForTesting
 import com.adobe.marketing.mobile.AdobeCallback
 import com.adobe.marketing.mobile.Assurance
-import com.adobe.marketing.mobile.assurance.AssuranceConstants.AssuranceQuickConnectError
+import com.adobe.marketing.mobile.assurance.AssuranceConstants.AssuranceConnectionError
 import com.adobe.marketing.mobile.assurance.AssuranceConstants.QuickConnect
 import com.adobe.marketing.mobile.services.HttpConnecting
 import com.adobe.marketing.mobile.services.HttpMethod
@@ -37,7 +37,7 @@ internal class QuickConnectDeviceCreator(
     private val orgId: String,
     private val clientId: String,
     private val deviceName: String,
-    private val callback: AdobeCallback<Response<HttpConnecting, AssuranceQuickConnectError>>
+    private val callback: AdobeCallback<Response<HttpConnecting, AssuranceConnectionError>>
 ) : Runnable {
 
     companion object {
@@ -53,7 +53,7 @@ internal class QuickConnectDeviceCreator(
         }
 
         if (networkRequest == null) {
-            callback.call(Response.Failure(AssuranceQuickConnectError.CREATE_DEVICE_REQUEST_MALFORMED))
+            callback.call(Response.Failure(AssuranceConnectionError.CREATE_DEVICE_REQUEST_MALFORMED))
             return
         }
 
@@ -97,7 +97,7 @@ internal class QuickConnectDeviceCreator(
     private fun makeRequest(networkRequest: NetworkRequest) {
         ServiceProvider.getInstance().networkService.connectAsync(networkRequest) { response: HttpConnecting? ->
             if (response == null) {
-                callback.call(Response.Failure(AssuranceQuickConnectError.UNEXPECTED_ERROR))
+                callback.call(Response.Failure(AssuranceConnectionError.UNEXPECTED_ERROR))
                 return@connectAsync
             }
 
@@ -113,7 +113,7 @@ internal class QuickConnectDeviceCreator(
             } else {
                 Log.trace(Assurance.LOG_TAG, LOG_SOURCE, "Device registration failed with code : $responseCode and message: ${response.responseMessage}.")
                 callback.call(
-                    Response.Failure(AssuranceQuickConnectError.CREATE_DEVICE_REQUEST_FAILED)
+                    Response.Failure(AssuranceConnectionError.CREATE_DEVICE_REQUEST_FAILED)
                 )
             }
 
@@ -126,7 +126,7 @@ internal class QuickConnectDeviceCreator(
      * exposing the getter for callback in the constructor itself because the annotations are not retained with that way.
      */
     @VisibleForTesting
-    fun getCallback(): AdobeCallback<Response<HttpConnecting, AssuranceQuickConnectError>> {
+    fun getCallback(): AdobeCallback<Response<HttpConnecting, AssuranceConnectionError>> {
         return callback
     }
 }

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/QuickConnectDeviceStatusChecker.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/QuickConnectDeviceStatusChecker.kt
@@ -14,7 +14,7 @@ package com.adobe.marketing.mobile.assurance
 import androidx.annotation.VisibleForTesting
 import com.adobe.marketing.mobile.AdobeCallback
 import com.adobe.marketing.mobile.Assurance.LOG_TAG
-import com.adobe.marketing.mobile.assurance.AssuranceConstants.AssuranceQuickConnectError
+import com.adobe.marketing.mobile.assurance.AssuranceConstants.AssuranceConnectionError
 import com.adobe.marketing.mobile.assurance.AssuranceConstants.QuickConnect
 import com.adobe.marketing.mobile.services.HttpConnecting
 import com.adobe.marketing.mobile.services.HttpMethod
@@ -36,7 +36,7 @@ import javax.net.ssl.HttpsURLConnection
 internal class QuickConnectDeviceStatusChecker(
     private val orgId: String,
     private val clientId: String,
-    private val callback: AdobeCallback<Response<HttpConnecting, AssuranceQuickConnectError>>
+    private val callback: AdobeCallback<Response<HttpConnecting, AssuranceConnectionError>>
 ) : Runnable {
 
     companion object {
@@ -52,7 +52,7 @@ internal class QuickConnectDeviceStatusChecker(
         }
 
         if (networkRequest == null) {
-            callback.call(Response.Failure(AssuranceQuickConnectError.STATUS_CHECK_REQUEST_MALFORMED))
+            callback.call(Response.Failure(AssuranceConnectionError.STATUS_CHECK_REQUEST_MALFORMED))
             return
         }
 
@@ -92,14 +92,14 @@ internal class QuickConnectDeviceStatusChecker(
     private fun makeRequest(networkRequest: NetworkRequest) {
         ServiceProvider.getInstance().networkService.connectAsync(networkRequest) { response: HttpConnecting? ->
             if (response == null) {
-                callback.call(Response.Failure(AssuranceQuickConnectError.UNEXPECTED_ERROR))
+                callback.call(Response.Failure(AssuranceConnectionError.UNEXPECTED_ERROR))
                 return@connectAsync
             }
 
             val responseCode = response.responseCode
             if (!(responseCode == HttpsURLConnection.HTTP_CREATED || responseCode == HttpsURLConnection.HTTP_OK)) {
                 Log.trace(LOG_TAG, LOG_SOURCE, "Device status check failed with code : $responseCode and message: ${response.responseMessage}.")
-                callback.call(Response.Failure(AssuranceQuickConnectError.DEVICE_STATUS_REQUEST_FAILED))
+                callback.call(Response.Failure(AssuranceConnectionError.DEVICE_STATUS_REQUEST_FAILED))
             } else {
                 callback.call(Response.Success(response))
             }
@@ -113,7 +113,7 @@ internal class QuickConnectDeviceStatusChecker(
      * exposing the getter for callback in the constructor itself because the annotations are not retained with that way.
      */
     @VisibleForTesting
-    internal fun getCallback(): AdobeCallback<Response<HttpConnecting, AssuranceQuickConnectError>> {
+    internal fun getCallback(): AdobeCallback<Response<HttpConnecting, AssuranceConnectionError>> {
         return callback
     }
 }

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/QuickConnectManager.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/QuickConnectManager.kt
@@ -13,7 +13,7 @@ package com.adobe.marketing.mobile.assurance
 
 import androidx.annotation.VisibleForTesting
 import com.adobe.marketing.mobile.Assurance.LOG_TAG
-import com.adobe.marketing.mobile.assurance.AssuranceConstants.AssuranceQuickConnectError
+import com.adobe.marketing.mobile.assurance.AssuranceConstants.AssuranceConnectionError
 import com.adobe.marketing.mobile.assurance.AssuranceConstants.QuickConnect
 import com.adobe.marketing.mobile.services.HttpConnecting
 import com.adobe.marketing.mobile.services.Log
@@ -130,7 +130,7 @@ internal class QuickConnectManager(
      * @param clientId the clientId for which quick connect was initiated
      * @param response the [Response] from the [checkDeviceStatus] request that is to be handled
      */
-    private fun handleStatusCheckResponse(orgId: String, clientId: String, response: Response<HttpConnecting, AssuranceQuickConnectError>) {
+    private fun handleStatusCheckResponse(orgId: String, clientId: String, response: Response<HttpConnecting, AssuranceConnectionError>) {
         when (response) {
             is Response.Success -> {
                 val sessionDetails = extractSessionDetails(StreamUtils.readAsString(response.data.inputStream))
@@ -157,7 +157,7 @@ internal class QuickConnectManager(
                 } else {
                     // Maximum allowed retries for checking the status has been reached.
                     Log.trace(LOG_TAG, LOG_SOURCE, "Will not retry. Maximum allowed retries for status check have been reached.")
-                    quickConnectCallback.onError(AssuranceQuickConnectError.RETRY_LIMIT_REACHED)
+                    quickConnectCallback.onError(AssuranceConnectionError.RETRY_LIMIT_REACHED)
                     cleanup()
                 }
             }

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/QuickConnectDeviceCreatorTest.kt
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/QuickConnectDeviceCreatorTest.kt
@@ -12,7 +12,7 @@
 package com.adobe.marketing.mobile.assurance
 
 import com.adobe.marketing.mobile.AdobeCallback
-import com.adobe.marketing.mobile.assurance.AssuranceConstants.AssuranceQuickConnectError
+import com.adobe.marketing.mobile.assurance.AssuranceConstants.AssuranceConnectionError
 import com.adobe.marketing.mobile.assurance.AssuranceConstants.QuickConnect
 import com.adobe.marketing.mobile.assurance.AssuranceTestUtils.simulateNetworkResponse
 import com.adobe.marketing.mobile.assurance.AssuranceTestUtils.verifyNetworkRequestParams
@@ -55,7 +55,7 @@ class QuickConnectDeviceCreatorTest {
     private lateinit var mockServiceProvider: ServiceProvider
 
     @Mock
-    private lateinit var mockCallback: AdobeCallback<Response<HttpConnecting, AssuranceQuickConnectError>>
+    private lateinit var mockCallback: AdobeCallback<Response<HttpConnecting, AssuranceConnectionError>>
 
     private lateinit var mockedStaticServiceProvider: MockedStatic<ServiceProvider>
 
@@ -154,10 +154,10 @@ class QuickConnectDeviceCreatorTest {
         val simulatedResponse = simulateNetworkResponse(HttpURLConnection.HTTP_OK, "ResponseData".byteInputStream(), mapOf())
         capturedNetworkCallback.call(simulatedResponse)
 
-        val responseCaptor: KArgumentCaptor<Response<HttpConnecting, AssuranceQuickConnectError>> = argumentCaptor()
+        val responseCaptor: KArgumentCaptor<Response<HttpConnecting, AssuranceConnectionError>> = argumentCaptor()
         verify(mockCallback).call(responseCaptor.capture())
 
-        val capturedResponse: Response<HttpConnecting, AssuranceQuickConnectError> = responseCaptor.firstValue
+        val capturedResponse: Response<HttpConnecting, AssuranceConnectionError> = responseCaptor.firstValue
         if (capturedResponse is Response.Success) {
             assertEquals(simulatedResponse.inputStream, capturedResponse.data.inputStream)
             assertEquals(simulatedResponse.responseCode, capturedResponse.data.responseCode)
@@ -213,13 +213,13 @@ class QuickConnectDeviceCreatorTest {
         val simulatedResponse = simulateNetworkResponse(HttpURLConnection.HTTP_NOT_FOUND, null, mapOf())
         capturedNetworkCallback.call(simulatedResponse)
 
-        val responseCaptor: KArgumentCaptor<Response<HttpConnecting, AssuranceQuickConnectError>> = argumentCaptor()
+        val responseCaptor: KArgumentCaptor<Response<HttpConnecting, AssuranceConnectionError>> = argumentCaptor()
         verify(mockCallback).call(responseCaptor.capture())
 
-        val capturedResponse: Response<HttpConnecting, AssuranceQuickConnectError> = responseCaptor.firstValue
+        val capturedResponse: Response<HttpConnecting, AssuranceConnectionError> = responseCaptor.firstValue
 
         if (capturedResponse is Response.Failure) {
-            assertEquals(AssuranceQuickConnectError.CREATE_DEVICE_REQUEST_FAILED, capturedResponse.error)
+            assertEquals(AssuranceConnectionError.CREATE_DEVICE_REQUEST_FAILED, capturedResponse.error)
         } else {
             fail("Error response should have been delivered.")
         }
@@ -271,13 +271,13 @@ class QuickConnectDeviceCreatorTest {
         // simulate null response for the request
         capturedNetworkCallback.call(null)
 
-        val responseCaptor: KArgumentCaptor<Response<HttpConnecting, AssuranceQuickConnectError>> = argumentCaptor()
+        val responseCaptor: KArgumentCaptor<Response<HttpConnecting, AssuranceConnectionError>> = argumentCaptor()
         verify(mockCallback).call(responseCaptor.capture())
 
-        val capturedResponse: Response<HttpConnecting, AssuranceQuickConnectError> = responseCaptor.firstValue
+        val capturedResponse: Response<HttpConnecting, AssuranceConnectionError> = responseCaptor.firstValue
 
         if (capturedResponse is Response.Failure) {
-            assertEquals(AssuranceQuickConnectError.UNEXPECTED_ERROR, capturedResponse.error)
+            assertEquals(AssuranceConnectionError.UNEXPECTED_ERROR, capturedResponse.error)
         } else {
             fail("Error response should have been delivered.")
         }

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/QuickConnectDeviceStatusCheckerTest.kt
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/QuickConnectDeviceStatusCheckerTest.kt
@@ -52,7 +52,7 @@ class QuickConnectDeviceStatusCheckerTest {
     private lateinit var mockServiceProvider: ServiceProvider
 
     @Mock
-    private lateinit var mockCallback: AdobeCallback<Response<HttpConnecting, AssuranceConstants.AssuranceQuickConnectError>>
+    private lateinit var mockCallback: AdobeCallback<Response<HttpConnecting, AssuranceConstants.AssuranceConnectionError>>
 
     private lateinit var mockedStaticServiceProvider: MockedStatic<ServiceProvider>
 
@@ -150,10 +150,10 @@ class QuickConnectDeviceStatusCheckerTest {
         val simulatedResponse = simulateNetworkResponse(HttpURLConnection.HTTP_OK, "ResponseData".byteInputStream(), mapOf())
         capturedNetworkCallback.call(simulatedResponse)
 
-        val responseCaptor: KArgumentCaptor<Response<HttpConnecting, AssuranceConstants.AssuranceQuickConnectError>> = argumentCaptor()
+        val responseCaptor: KArgumentCaptor<Response<HttpConnecting, AssuranceConstants.AssuranceConnectionError>> = argumentCaptor()
         verify(mockCallback).call(responseCaptor.capture())
 
-        val capturedResponse: Response<HttpConnecting, AssuranceConstants.AssuranceQuickConnectError> = responseCaptor.firstValue
+        val capturedResponse: Response<HttpConnecting, AssuranceConstants.AssuranceConnectionError> = responseCaptor.firstValue
         if (capturedResponse is Response.Success) {
             assertEquals(simulatedResponse.inputStream, capturedResponse.data.inputStream)
             assertEquals(simulatedResponse.responseCode, capturedResponse.data.responseCode)
@@ -208,13 +208,13 @@ class QuickConnectDeviceStatusCheckerTest {
         val simulatedResponse = simulateNetworkResponse(HttpURLConnection.HTTP_NOT_FOUND, null, mapOf())
         capturedNetworkCallback.call(simulatedResponse)
 
-        val responseCaptor: KArgumentCaptor<Response<HttpConnecting, AssuranceConstants.AssuranceQuickConnectError>> = argumentCaptor()
+        val responseCaptor: KArgumentCaptor<Response<HttpConnecting, AssuranceConstants.AssuranceConnectionError>> = argumentCaptor()
         verify(mockCallback).call(responseCaptor.capture())
 
-        val capturedResponse: Response<HttpConnecting, AssuranceConstants.AssuranceQuickConnectError> = responseCaptor.firstValue
+        val capturedResponse: Response<HttpConnecting, AssuranceConstants.AssuranceConnectionError> = responseCaptor.firstValue
 
         if (capturedResponse is Response.Failure) {
-            assertEquals(AssuranceConstants.AssuranceQuickConnectError.DEVICE_STATUS_REQUEST_FAILED, capturedResponse.error)
+            assertEquals(AssuranceConstants.AssuranceConnectionError.DEVICE_STATUS_REQUEST_FAILED, capturedResponse.error)
         } else {
             fail("Error response should have been delivered.")
         }
@@ -265,13 +265,13 @@ class QuickConnectDeviceStatusCheckerTest {
         // simulate null response for the request
         capturedNetworkCallback.call(null)
 
-        val responseCaptor: KArgumentCaptor<Response<HttpConnecting, AssuranceConstants.AssuranceQuickConnectError>> = argumentCaptor()
+        val responseCaptor: KArgumentCaptor<Response<HttpConnecting, AssuranceConstants.AssuranceConnectionError>> = argumentCaptor()
         verify(mockCallback).call(responseCaptor.capture())
 
-        val capturedResponse: Response<HttpConnecting, AssuranceConstants.AssuranceQuickConnectError> = responseCaptor.firstValue
+        val capturedResponse: Response<HttpConnecting, AssuranceConstants.AssuranceConnectionError> = responseCaptor.firstValue
 
         if (capturedResponse is Response.Failure) {
-            assertEquals(AssuranceConstants.AssuranceQuickConnectError.UNEXPECTED_ERROR, capturedResponse.error)
+            assertEquals(AssuranceConstants.AssuranceConnectionError.UNEXPECTED_ERROR, capturedResponse.error)
         } else {
             fail("Error response should have been delivered.")
         }

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/QuickConnectManagerTest.kt
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/QuickConnectManagerTest.kt
@@ -11,7 +11,7 @@
 
 package com.adobe.marketing.mobile.assurance
 
-import com.adobe.marketing.mobile.assurance.AssuranceConstants.AssuranceQuickConnectError
+import com.adobe.marketing.mobile.assurance.AssuranceConstants.AssuranceConnectionError
 import com.adobe.marketing.mobile.assurance.AssuranceConstants.QuickConnect
 import com.adobe.marketing.mobile.assurance.AssuranceTestUtils.simulateNetworkResponse
 import com.adobe.marketing.mobile.services.DeviceInforming
@@ -173,16 +173,16 @@ class QuickConnectManagerTest {
 
         // simulate REQUEST_FAILED response
         val quickConnectDeviceStatusCheckerCaptor: KArgumentCaptor<QuickConnectDeviceStatusChecker> = argumentCaptor()
-        capturedDeviceCreationTask.getCallback().call(Response.Failure(AssuranceQuickConnectError.CREATE_DEVICE_REQUEST_FAILED))
+        capturedDeviceCreationTask.getCallback().call(Response.Failure(AssuranceConnectionError.CREATE_DEVICE_REQUEST_FAILED))
         verify(mockExecutorService, never()).schedule(quickConnectDeviceStatusCheckerCaptor.capture(), anyLong(), any(TimeUnit::class.java))
 
-        verify(mockQuickConnectCallback).onError(AssuranceQuickConnectError.CREATE_DEVICE_REQUEST_FAILED)
+        verify(mockQuickConnectCallback).onError(AssuranceConnectionError.CREATE_DEVICE_REQUEST_FAILED)
 
         // simulate UNEXPECTED_ERROR response
-        capturedDeviceCreationTask.getCallback().call(Response.Failure(AssuranceQuickConnectError.UNEXPECTED_ERROR))
+        capturedDeviceCreationTask.getCallback().call(Response.Failure(AssuranceConnectionError.UNEXPECTED_ERROR))
         verify(mockExecutorService, never()).schedule(quickConnectDeviceStatusCheckerCaptor.capture(), anyLong(), any(TimeUnit::class.java))
 
-        verify(mockQuickConnectCallback).onError(AssuranceQuickConnectError.UNEXPECTED_ERROR)
+        verify(mockQuickConnectCallback).onError(AssuranceConnectionError.UNEXPECTED_ERROR)
     }
 
     @Test


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently PIN based connection error codes and quick connect error codes exist separately. This distinction is not need and can be unified similar to Assurance iOS.

- Unify `AssuranceSocketError` and `AssuranceQuickConnectError` to `AssuranceConnectionError`.
- Add AssuranceConnectionError as a parameter to session status notifications to provide details of termination if any. This is useful for presentations like QuickConnect for managing their lifecycle by registerting as session status listeners as it is a native activity where dependency injection is not possible and reference to the activity/presentation for notifying chanages is not available.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Currently PIN based connection error codes and quick connect error codes exist separately. This distinction is not need and can be unified similar to Assurance iOS.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Unit tests.
- Smoke tests with test app.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.