### PR TITLE
Add public API for QuickConnect and integrate with AssuranceTestApp

### DIFF
--- a/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/ui/views/AssuranceView.kt
+++ b/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/ui/views/AssuranceView.kt
@@ -119,6 +119,13 @@ private fun AssuranceConnectionInput() {
         ) {
             Text(text = stringResource(id = R.string.assurance_connection_button_name))
         }
+
+        Button(
+            onClick = { Assurance.startSession() },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(text = stringResource(id = R.string.assurance_quick_connect_button_name))
+        }
     }
 }
 

--- a/code/assurance-testapp/src/main/res/values/strings.xml
+++ b/code/assurance-testapp/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="assurance_version">Assurance v%1$s</string>
     <string name="assurance_connection_input_hint">Enter Assurance Connection URL</string>
     <string name="assurance_connection_button_name">Start Session</string>
+    <string name="assurance_quick_connect_button_name">Quick Connect</string>
 
     <string name="event_chunking_section_title">Event Chunking</string>
     <string name="send_small_payload_button_name">Send Small Payload</string>

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/Assurance.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/Assurance.java
@@ -15,6 +15,7 @@ package com.adobe.marketing.mobile;
 import androidx.annotation.NonNull;
 import com.adobe.marketing.mobile.assurance.AssuranceExtension;
 import com.adobe.marketing.mobile.services.Log;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +30,7 @@ public class Assurance {
 
     private static final String DEEPLINK_SESSION_ID_KEY = "adb_validation_sessionid";
     private static final String START_SESSION_URL = "startSessionURL";
+    private static final String IS_QUICK_CONNECT = "quickConnect";
 
     // ========================================================================================
     // Public APIs
@@ -99,6 +101,25 @@ public class Assurance {
                                 EventType.ASSURANCE,
                                 EventSource.REQUEST_CONTENT)
                         .setEventData(startSessionEventData)
+                        .build();
+        MobileCore.dispatchEvent(startSessionEvent);
+    }
+
+    /**
+     * Starts an Assurance session via quick flow. Invoking this method on a non-debuggable build,
+     * or when a session already exists will result in a no-op.
+     */
+    public static void startSession() {
+        Log.debug(LOG_TAG, LOG_TAG, "QuickConnect api triggered.");
+
+        // Send a quick connect start session event irrespective of the build here.
+        // Validation will be done when the extension handles this event.
+        final Event startSessionEvent =
+                new Event.Builder(
+                                "Assurance Start Session (Quick Connect)",
+                                EventType.ASSURANCE,
+                                EventSource.REQUEST_CONTENT)
+                        .setEventData(Collections.singletonMap(IS_QUICK_CONNECT, true))
                         .build();
         MobileCore.dispatchEvent(startSessionEvent);
     }

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceConstants.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceConstants.java
@@ -41,6 +41,7 @@ final class AssuranceConstants {
 
     static final class SDKEventDataKey {
         static final String START_SESSION_URL = "startSessionURL";
+        static final String IS_QUICK_CONNECT = "quickConnect";
         static final String EXTENSIONS = "extensions";
         static final String STATE_OWNER = "stateowner";
         static final String FRIENDLY_NAME = "friendlyName";

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceQuickConnectActivity.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceQuickConnectActivity.kt
@@ -157,6 +157,7 @@ class AssuranceQuickConnectActivity : AppCompatActivity() {
     ) {
         cancelButtonView.setOnClickListener {
             quickConnectManager.cancel()
+            AssuranceComponentRegistry.sessionUIOperationHandler?.onCancel()
             finish()
         }
     }

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/QuickConnectManager.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/QuickConnectManager.kt
@@ -186,7 +186,11 @@ internal class QuickConnectManager(
             val jsonObject = JSONObject(JSONTokener(jsonString))
             val sessionUUID = jsonObject.optString(QuickConnect.KEY_SESSION_ID)
             val token = jsonObject.optString(QuickConnect.KEY_SESSION_TOKEN)
-            if (StringUtils.isNullOrEmpty(sessionUUID) || StringUtils.isNullOrEmpty(token)) {
+            if (StringUtils.isNullOrEmpty(sessionUUID) ||
+                StringUtils.isNullOrEmpty(token) ||
+                "null".equals(sessionUUID, true) ||
+                "null".equals(token, true)
+            ) {
                 null
             } else {
                 QuickConnectSessionDetails(sessionUUID, token)

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceTest.java
@@ -11,7 +11,8 @@
 
 package com.adobe.marketing.mobile.assurance;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -23,6 +24,7 @@ import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.ExtensionError;
 import com.adobe.marketing.mobile.ExtensionErrorCallback;
 import com.adobe.marketing.mobile.MobileCore;
+import com.adobe.marketing.mobile.util.DataReader;
 import junit.framework.TestCase;
 import org.junit.After;
 import org.junit.Before;
@@ -108,6 +110,29 @@ public class AssuranceTest {
 
         // test 2 - ErrorCallback is handled without crashing
         extensionErrorCallbackCaptor.getValue().error(ExtensionError.UNEXPECTED_ERROR);
+    }
+
+    @Test
+    public void test_startSession_quickConnect() {
+        // prepare
+        final ArgumentCaptor<Event> dispatchedEventCaptor = ArgumentCaptor.forClass(Event.class);
+
+        // test
+        Assurance.startSession();
+
+        // verify
+        mockedStaticMobileCore.verify(
+                () -> MobileCore.dispatchEvent(dispatchedEventCaptor.capture()), times(1));
+
+        final Event dispatchedEvent = dispatchedEventCaptor.getValue();
+        assertEquals(EventType.ASSURANCE, dispatchedEvent.getType());
+        assertEquals(EventSource.REQUEST_CONTENT, dispatchedEvent.getSource());
+        assertEquals("Assurance Start Session (Quick Connect)", dispatchedEvent.getName());
+        assertTrue(
+                DataReader.optBoolean(
+                        dispatchedEvent.getEventData(),
+                        AssuranceConstants.SDKEventDataKey.IS_QUICK_CONNECT,
+                        false));
     }
 
     @After


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR adds the final piece to expose quick connect workflow via the public `startSession()` api. 

## Description
- Add `startSession()` api that dispatches an event with `isQuickConnect` flag. 
- Handle the Assurance request event in AssuranceExtension to conditionally start a deeplink session or a quick connect session based on the event data.
- Make the extension handle this event only of the application is debuggable. Event handling is dropped on non-debug builds.
- Add tests
<!--- Describe your changes in detail -->

## Related Issue
#37 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Unit tests
- Manual tests to ensure that the api is not handled in non-debuggable builds

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.