### PR TITLE
Make AssuranceErrorDisplayActivity extend Activity

### DIFF
--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceErrorDisplayActivity.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceErrorDisplayActivity.java
@@ -12,17 +12,17 @@
 package com.adobe.marketing.mobile.assurance;
 
 
+import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.view.Window;
 import android.widget.Button;
 import android.widget.TextView;
-import androidx.appcompat.app.AppCompatActivity;
 import com.adobe.marketing.mobile.Assurance;
 import com.adobe.marketing.mobile.services.Log;
 
-public class AssuranceErrorDisplayActivity extends AppCompatActivity {
+public class AssuranceErrorDisplayActivity extends Activity {
     private static final String LOG_TAG = "AssuranceErrorDisplayActivity";
 
     @Override


### PR DESCRIPTION
A recent change that was done to remove themes missed switching AssuranceErrorDisplayActivity extend Activity. Switch it now.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Assurance now does not expose/use themes. So all references to activities that require a theme should be switched to Activity. A recent change that was done to remove themes missed switching AssuranceErrorDisplayActivity extend Activity. Switch it now.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.