### PR TITLE
Update Assurance Test App with testTags for automation

### DIFF
--- a/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/AssuranceTestApp.kt
+++ b/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/AssuranceTestApp.kt
@@ -22,16 +22,11 @@ import com.adobe.marketing.mobile.assurance.testapp.AssuranceTestAppConstants.TA
 
 class AssuranceTestApp : Application() {
 
-    companion object {
-        private const val APP_ID = "YOUR_APP_ID"
-    }
-
     override fun onCreate() {
         super.onCreate()
 
         MobileCore.setApplication(this)
         MobileCore.setLogLevel(LoggingMode.VERBOSE)
-        MobileCore.configureWithAppID(APP_ID)
 
         MobileCore.registerExtensions(
             listOf(

--- a/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/AssuranceTestAppActivity.kt
+++ b/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/AssuranceTestAppActivity.kt
@@ -34,6 +34,7 @@ import androidx.compose.material.rememberScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.navigation.compose.rememberNavController
@@ -114,6 +115,7 @@ private fun AssuranceTestAppTopBar(onNavIconClick: () -> Unit) {
         },
         navigationIcon = {
             IconButton(
+                modifier = Modifier.testTag(AssuranceTestAppConstants.TEST_TAG_TEST_APP_MENU_BUTTON),
                 onClick = {
                     onNavIconClick()
                 }

--- a/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/AssuranceTestAppConstants.kt
+++ b/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/AssuranceTestAppConstants.kt
@@ -25,4 +25,19 @@ object AssuranceTestAppConstants {
     const val TEST_EVENT_NAME = "TestEvent"
     const val TEST_EVENT_SOURCE = "TestSource"
     const val TEST_EVENT_TYPE = "TestType"
+
+    // Test Tags
+    const val TEST_TAG_TEST_APP_MENU_BUTTON = "testAppMenuButton"
+    const val TEST_TAG_ASSURANCE_SCREEN = "assuranceScreen"
+    const val TEST_TAG_APP_ID_INPUT = "appIdInput"
+    const val TEST_TAG_CONFIGURE_WITH_APP_ID_BUTTON = "configWithAppIdButton"
+    const val TEST_TAG_SESSION_URL_INPUT = "sessionUrlInput"
+    const val TEST_TAG_START_SESSION_BUTTON = "startSessionButton"
+    const val TEST_TAG_QUICK_CONNECT_BUTTON = "quickConnectButton"
+    const val TEST_TAG_CORE_SCREEN = "coreScreen"
+    const val TEST_TAG_EVENTS_SECTION = "eventSection"
+    const val TEST_TAG_TRACK_ACTION_BUTTON = "trackActionButton"
+    const val TEST_TAG_TRACK_STATE_BUTTON = "trackStateButton"
+    const val TEST_TAG_DISPATCH_EVENT_BUTTON = "dispatchEventButton"
+
 }

--- a/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/ui/navigation/NavRoutes.kt
+++ b/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/ui/navigation/NavRoutes.kt
@@ -11,7 +11,9 @@
 
 package com.adobe.marketing.mobile.assurance.testapp.ui.navigation
 
-internal sealed class NavRoutes(val route: String, val title: String) {
-    object AssuranceRoute : NavRoutes("Assurance", "Assurance")
-    object CoreRoute : NavRoutes("Core", "Core")
+import com.adobe.marketing.mobile.assurance.testapp.AssuranceTestAppConstants
+
+internal sealed class NavRoutes(val route: String, val title: String, val testTag: String) {
+    object AssuranceRoute : NavRoutes("Assurance", "Assurance", AssuranceTestAppConstants.TEST_TAG_ASSURANCE_SCREEN)
+    object CoreRoute : NavRoutes("Core", "Core", AssuranceTestAppConstants.TEST_TAG_CORE_SCREEN)
 }

--- a/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/ui/views/AssuranceView.kt
+++ b/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/ui/views/AssuranceView.kt
@@ -30,12 +30,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.adobe.marketing.mobile.Assurance
+import com.adobe.marketing.mobile.MobileCore
 import com.adobe.marketing.mobile.assurance.testapp.AssuranceTestAppConstants
 import com.adobe.marketing.mobile.assurance.testapp.R
 import com.adobe.marketing.mobile.assurance.testapp.ui.viewmodel.AssuranceTestAppViewModel
@@ -47,7 +49,7 @@ internal fun AssuranceScreen(
     scope: CoroutineScope,
     assuranceTestAppViewModel: AssuranceTestAppViewModel
 ) {
-    Box() {
+    Box(modifier = Modifier.testTag(AssuranceTestAppConstants.TEST_TAG_ASSURANCE_SCREEN)) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -62,6 +64,15 @@ internal fun AssuranceScreen(
             ) {
                 AssuranceVersionLabel(version = Assurance.extensionVersion())
             }
+
+            Row(
+                modifier = Modifier
+                    .padding(vertical = 16.dp, horizontal = 8.dp)
+                    .align(Alignment.CenterHorizontally)
+            ) {
+                AppIdConfiguration()
+            }
+
             Row(
                 modifier = Modifier
                     .padding(vertical = 16.dp, horizontal = 8.dp)
@@ -110,21 +121,56 @@ private fun AssuranceConnectionInput() {
             value = assuranceSessionUrl,
             onValueChange = { assuranceSessionUrl = it },
             placeholder = { Text(text = stringResource(id = R.string.assurance_connection_input_hint)) },
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(AssuranceTestAppConstants.TEST_TAG_SESSION_URL_INPUT)
         )
 
         Button(
             onClick = { Assurance.startSession(assuranceSessionUrl) },
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(AssuranceTestAppConstants.TEST_TAG_START_SESSION_BUTTON)
         ) {
             Text(text = stringResource(id = R.string.assurance_connection_button_name))
         }
 
         Button(
             onClick = { Assurance.startSession() },
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(AssuranceTestAppConstants.TEST_TAG_QUICK_CONNECT_BUTTON)
         ) {
             Text(text = stringResource(id = R.string.assurance_quick_connect_button_name))
+        }
+    }
+}
+
+@Composable
+private fun AppIdConfiguration() {
+    var appId by remember {
+        mutableStateOf("")
+    }
+    Column {
+        TextField(
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Text
+            ),
+            value = appId,
+            onValueChange = { appId = it },
+            placeholder = { Text(text = stringResource(id = R.string.assurance_appId_input_hint)) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(AssuranceTestAppConstants.TEST_TAG_APP_ID_INPUT)
+        )
+
+        Button(
+            onClick = { MobileCore.configureWithAppID(appId) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(AssuranceTestAppConstants.TEST_TAG_CONFIGURE_WITH_APP_ID_BUTTON)
+        ) {
+            Text(text = stringResource(id = R.string.assurance_appId_button_name))
         }
     }
 }

--- a/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/ui/views/CoreView.kt
+++ b/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/ui/views/CoreView.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextDecoration
@@ -34,7 +35,7 @@ import com.adobe.marketing.mobile.assurance.testapp.R
 
 @Composable
 internal fun CoreScreen() {
-    Column {
+    Column(modifier = Modifier.testTag(AssuranceTestAppConstants.TEST_TAG_CORE_SCREEN)) {
 
         Row() {
             PrivacySection()
@@ -96,7 +97,7 @@ private fun PrivacySection() {
 
 @Composable
 private fun EventSection() {
-    Column() {
+    Column(modifier = Modifier.testTag(AssuranceTestAppConstants.TEST_TAG_EVENTS_SECTION)) {
         Row(
             Modifier
                 .align(Alignment.CenterHorizontally)
@@ -106,7 +107,8 @@ private fun EventSection() {
                 text = stringResource(id = R.string.event_section_title),
                 fontWeight = FontWeight.Bold,
                 fontSize = 18.sp,
-                textDecoration = TextDecoration.Underline
+                textDecoration = TextDecoration.Underline,
+                modifier = Modifier.padding(8.dp).testTag(AssuranceTestAppConstants.TEST_TAG_TRACK_ACTION_BUTTON)
             )
         }
 
@@ -124,7 +126,7 @@ private fun EventSection() {
                         mapOf("sampleKey" to "sampleValue")
                     )
                 },
-                modifier = Modifier.padding(8.dp)
+                modifier = Modifier.padding(8.dp).testTag(AssuranceTestAppConstants.TEST_TAG_TRACK_ACTION_BUTTON)
             ) {
                 Text(text = stringResource(id = R.string.track_action_button))
             }
@@ -136,7 +138,7 @@ private fun EventSection() {
                         mapOf("sampleKey" to "sampleValue")
                     )
                 },
-                modifier = Modifier.padding(8.dp)
+                modifier = Modifier.padding(8.dp).testTag(AssuranceTestAppConstants.TEST_TAG_TRACK_STATE_BUTTON)
             ) {
                 Text(text = stringResource(id = R.string.track_state_button))
             }
@@ -153,7 +155,7 @@ private fun EventSection() {
                             .build()
                     )
                 },
-                modifier = Modifier.padding(8.dp)
+                modifier = Modifier.padding(8.dp).testTag(AssuranceTestAppConstants.TEST_TAG_DISPATCH_EVENT_BUTTON)
             ) {
                 Text(text = stringResource(id = R.string.dispatch_event_button))
             }

--- a/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/ui/views/DrawerItem.kt
+++ b/code/assurance-testapp/src/main/java/com/adobe/marketing/mobile/assurance/testapp/ui/views/DrawerItem.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.adobe.marketing.mobile.assurance.testapp.ui.navigation.NavRoutes
@@ -41,6 +42,7 @@ internal fun DrawerItem(item: NavRoutes, selected: Boolean, onItemClick: (NavRou
             .height(45.dp)
             .background(color = background)
             .padding(start = 10.dp)
+            .testTag(item.testTag)
     ) {
 
         Spacer(modifier = Modifier.width(8.dp))

--- a/code/assurance-testapp/src/main/res/values/strings.xml
+++ b/code/assurance-testapp/src/main/res/values/strings.xml
@@ -16,6 +16,8 @@
     <string name="app_top_bar_description">Open Navigation Drawer</string>
 
     <string name="assurance_version">Assurance v%1$s</string>
+    <string name="assurance_appId_input_hint">Enter App Id</string>
+    <string name="assurance_appId_button_name">Configure With AppId</string>
     <string name="assurance_connection_input_hint">Enter Assurance Connection URL</string>
     <string name="assurance_connection_button_name">Start Session</string>
     <string name="assurance_quick_connect_button_name">Quick Connect</string>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Current TestApp lacks test tags for ui elements making it infeasible to do E2E automation with Appium/SauceLabs.

- Add test tags for UI elements that are clickable
- Add a mechanism to enter AppID for configuration before tests

_Git workflow for test app pr updates will be added as a followup PR._

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Use layout inspector to ensure that tags appear for desired elements.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.