### PR TITLE
Attach parentId to assurance event payload

### DIFF
--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceConstants.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceConstants.java
@@ -34,7 +34,8 @@ final class AssuranceConstants {
         static final String ACP_EXTENSION_EVENT_DATA = "ACPExtensionEventData";
         static final String ACP_EXTENSION_EVENT_UNIQUE_IDENTIFIER =
                 "ACPExtensionEventUniqueIdentifier";
-        static final String ACP_EXTENSION_EVENT_NUMBER = "ACPExtensionEventNumber";
+        static final String ACP_EXTENSION_EVENT_PARENT_IDENTIFIER =
+                "ACPExtensionEventParentIdentifier";
 
         private GenericEventPayloadKey() {}
     }

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceExtension.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceExtension.java
@@ -336,6 +336,11 @@ public final class AssuranceExtension extends Extension {
                 event.getUniqueIdentifier());
         payload.put(GenericEventPayloadKey.ACP_EXTENSION_EVENT_DATA, event.getEventData());
 
+        final String parentId = event.getParentID();
+        if (!StringUtils.isNullOrEmpty(parentId)) {
+            payload.put(GenericEventPayloadKey.ACP_EXTENSION_EVENT_PARENT_IDENTIFIER, parentId);
+        }
+
         // if the event is a shared state change event process differently
         if (EventSource.SHARED_STATE.equalsIgnoreCase(event.getSource())) {
             processSharedStateEvent(event, payload);

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -26,6 +26,6 @@ moduleVersion=2.1.0
 mavenRepoName=AdobeMobileAssurance
 mavenRepoDescription=Android Assurance Extension for Adobe Mobile Marketing
 mavenUploadDryRunFlag=false
-mavenCoreVersion=2.0.1
+mavenCoreVersion=2.2.2
 android.useAndroidX=true
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Core 2.2 added the ability to chain events. Use thst in formation to relay them to assurance events.

<!--- Describe your changes in detail -->

## Related Issue
#50 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Core 2.2 added the ability to chain events. Use thst in formation to relay them to assurance events.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.