### PR TITLE
Updates for triggering QuickConnect in Application.onCreate()

### DIFF
--- a/code/assurance/src/androidTest/java/com/adobe/marketing/mobile/assurance/AssuranceUtilTests.java
+++ b/code/assurance/src/androidTest/java/com/adobe/marketing/mobile/assurance/AssuranceUtilTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+package com.adobe.marketing.mobile.assurance;
+
+
+import android.net.Uri;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@link AssuranceUtil} that involve android specific constructs like {@link
+ * android.net.Uri} that cannot be mocked.
+ */
+public class AssuranceUtilTests {
+
+    @Test
+    public void testGetEnvironmentFromSocketUri() {
+        final Uri devSocketUri = Uri.parse("wss://connect-dev.griffon.adobe.com/client/v1");
+        Assert.assertEquals(
+                AssuranceConstants.AssuranceEnvironment.DEV,
+                AssuranceUtil.getEnvironmentFromSocketUri(devSocketUri));
+
+        final Uri qaSocketUri = Uri.parse("wss://connect-qa.griffon.adobe.com/client/v1");
+        Assert.assertEquals(
+                AssuranceConstants.AssuranceEnvironment.QA,
+                AssuranceUtil.getEnvironmentFromSocketUri(qaSocketUri));
+
+        final Uri stageSocketUri = Uri.parse("wss://connect-stage.griffon.adobe.com/client/v1");
+
+        Assert.assertEquals(
+                AssuranceConstants.AssuranceEnvironment.STAGE,
+                AssuranceUtil.getEnvironmentFromSocketUri(stageSocketUri));
+
+        final Uri prodSocketUri = Uri.parse("wss://connect.griffon.adobe.com/client/v1");
+        Assert.assertEquals(
+                AssuranceConstants.AssuranceEnvironment.PROD,
+                AssuranceUtil.getEnvironmentFromSocketUri(prodSocketUri));
+
+        final Uri invalidSocketUri = Uri.parse("wss://invalidconnect.griffon.adobe.com/client/v1");
+        Assert.assertEquals(
+                AssuranceConstants.AssuranceEnvironment.PROD,
+                AssuranceUtil.getEnvironmentFromSocketUri(invalidSocketUri));
+    }
+}

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceClientInfo.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceClientInfo.java
@@ -31,12 +31,22 @@ import com.adobe.marketing.mobile.services.ServiceProvider;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import org.json.JSONObject;
 
 final class AssuranceClientInfo {
 
     private static final String VALUE_UNKNOWN = "Unknown";
     private static final String MANIFEST_FILE_NAME = "AndroidManifest.xml";
     private static final String EVENT_TYPE_CONNECT = "connect";
+
+    private final JSONObject manifestData;
+
+    AssuranceClientInfo() {
+        // parse the manifest file and store it in a JSONObject for later use as this does not
+        // change
+        // during the lifetime of the application
+        manifestData = AssuranceIOUtils.parseXMLResourceFileToJson(MANIFEST_FILE_NAME);
+    }
 
     /**
      * Returns the payload for assurance ClientInfo event. ClientInfo event includes
@@ -57,9 +67,7 @@ final class AssuranceClientInfo {
         eventPayload.put(AssuranceConstants.ClientInfoKeys.VERSION, Assurance.extensionVersion());
         eventPayload.put(AssuranceConstants.ClientInfoKeys.DEVICE_INFO, getDeviceInfo());
         eventPayload.put(AssuranceConstants.PayloadDataKeys.TYPE, EVENT_TYPE_CONNECT);
-        eventPayload.put(
-                AssuranceConstants.ClientInfoKeys.APP_SETTINGS,
-                AssuranceIOUtils.parseXMLResourceFileToJson(MANIFEST_FILE_NAME));
+        eventPayload.put(AssuranceConstants.ClientInfoKeys.APP_SETTINGS, manifestData);
         return eventPayload;
     }
 

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceSessionOrchestrator.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceSessionOrchestrator.java
@@ -316,17 +316,18 @@ class AssuranceSessionOrchestrator {
             return false;
         }
 
-        final AssuranceConstants.AssuranceEnvironment environment =
-                AssuranceUtil.getEnvironmentFromQueryValue(
-                        uri.getQueryParameter(
-                                AssuranceConstants.DeeplinkURLKeys
-                                        .START_URL_QUERY_KEY_ENVIRONMENT));
         final String pin = uri.getQueryParameter(AssuranceConstants.DataStoreKeys.TOKEN);
 
         if (StringUtils.isNullOrEmpty(pin)) {
             return false;
         }
 
+        final AssuranceConstants.AssuranceEnvironment environmentFromUrl =
+                AssuranceUtil.getEnvironmentFromSocketUri(uri);
+        final AssuranceConstants.AssuranceEnvironment environment =
+                environmentFromUrl == null
+                        ? AssuranceConstants.AssuranceEnvironment.PROD
+                        : environmentFromUrl;
         Log.trace(
                 Assurance.LOG_TAG,
                 LOG_TAG,

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceUtil.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceUtil.java
@@ -78,6 +78,24 @@ final class AssuranceUtil {
     }
 
     /**
+     * Method to return the Assurance environment (if available) from socket uri.
+     *
+     * @param uri the Assurance socket connection uri
+     * @return the Assurance environment if available, null otherwise
+     */
+    static AssuranceEnvironment getEnvironmentFromSocketUri(final Uri uri) {
+        final Matcher matcher = CONNECTION_ROUTE_REGEX.matcher(uri.getHost());
+
+        if (!matcher.find()) return null;
+
+        // Group 3 is the environment in CONNECTION_ROUTE_REGEX
+        if (matcher.groupCount() < 3) return null;
+
+        final String environment = matcher.group(3);
+        return AssuranceEnvironment.get(environment);
+    }
+
+    /**
      * Use this method parse and obtain a valid sessionID from the deeplink URL
      *
      * <p>This method returns null in following occasions: 1.If the provided Uri is null 2.If the

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceClientInfoTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceClientInfoTest.java
@@ -65,22 +65,26 @@ public class AssuranceClientInfoTest {
     private MockedStatic<ServiceProvider> mockedStaticServiceProvider;
     private MockedStatic<ActivityCompat> mockedStaticActivityCompat;
 
+    private JSONObject appSettings;
+
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
-        assuranceClientInfo = new AssuranceClientInfo();
+
         mockedStaticActivityCompat = Mockito.mockStatic(ActivityCompat.class);
         mockedStaticAssuranceIOUtils = Mockito.mockStatic(AssuranceIOUtils.class);
         mockedStaticServiceProvider = Mockito.mockStatic(ServiceProvider.class);
-    }
 
-    @Test
-    public void testGetData_happy() throws JSONException {
-        final JSONObject appSettings = mockManifestData();
+        appSettings = mockManifestData();
         mockedStaticAssuranceIOUtils
                 .when(() -> AssuranceIOUtils.parseXMLResourceFileToJson(any()))
                 .thenReturn(appSettings);
 
+        assuranceClientInfo = new AssuranceClientInfo();
+    }
+
+    @Test
+    public void testGetData_happy() throws JSONException {
         mockAppContextService();
         mockTelephonyManager("MyNetworkCarrier");
         mockBatteryLevel(95);
@@ -115,11 +119,6 @@ public class AssuranceClientInfoTest {
 
     @Test
     public void testGetData_locationAuthorizationDenied() throws JSONException {
-        final JSONObject appSettings = mockManifestData();
-        mockedStaticAssuranceIOUtils
-                .when(() -> AssuranceIOUtils.parseXMLResourceFileToJson(any()))
-                .thenReturn(appSettings);
-
         mockAppContextService();
         mockTelephonyManager("MyNetworkCarrier");
         mockBatteryLevel(95);
@@ -154,11 +153,6 @@ public class AssuranceClientInfoTest {
 
     @Test
     public void testGetData_lowPowerModeEnabled() throws JSONException {
-        final JSONObject appSettings = mockManifestData();
-        mockedStaticAssuranceIOUtils
-                .when(() -> AssuranceIOUtils.parseXMLResourceFileToJson(any()))
-                .thenReturn(appSettings);
-
         mockAppContextService();
         mockTelephonyManager("MyNetworkCarrier");
         mockBatteryLevel(95);

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceExtensionTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceExtensionTest.java
@@ -239,7 +239,7 @@ public class AssuranceExtensionTest {
 
         assuranceExtension.startSession();
 
-        verify(mockActivity, times(0)).startActivity(any(Intent.class));
+        verify(mockApplication, times(0)).startActivity(any(Intent.class));
     }
 
     @Test
@@ -263,7 +263,7 @@ public class AssuranceExtensionTest {
 
         final ArgumentCaptor<Intent> quickConnectIntentCaptor =
                 ArgumentCaptor.forClass(Intent.class);
-        verify(mockActivity).startActivity(quickConnectIntentCaptor.capture());
+        verify(mockApplication).startActivity(quickConnectIntentCaptor.capture());
         final Intent capturedIntent = quickConnectIntentCaptor.getValue();
         assertEquals(
                 AssuranceQuickConnectActivity.class.getName(),
@@ -393,7 +393,7 @@ public class AssuranceExtensionTest {
         // verify that quick connect flow is launched
         final ArgumentCaptor<Intent> quickConnectIntentCaptor =
                 ArgumentCaptor.forClass(Intent.class);
-        verify(mockActivity).startActivity(quickConnectIntentCaptor.capture());
+        verify(mockApplication).startActivity(quickConnectIntentCaptor.capture());
         final Intent capturedIntent = quickConnectIntentCaptor.getValue();
         assertEquals(
                 AssuranceQuickConnectActivity.class.getName(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Assurance.startSession() can be triggered in the Application.onCreate() before Core has an active activity. Use the applicationContext to launch the quick connect activity in that case.
- `clientInfo` event can be sent multiple times. Do not read the manifest file for every event as the Manifest file does not change for the app after launch.
- Fix an issue that prevents re connecting when a working with non-prod environments.
<!--- Describe your changes in detail -->

## Related Issue
N/A
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Unit tests
- Manual tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.