### PR TITLE
Add support for QuickConnect environment selection

### DIFF
--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceConstants.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceConstants.java
@@ -265,7 +265,8 @@ final class AssuranceConstants {
     }
 
     static final class QuickConnect {
-        static final String BASE_DEVICE_API_URL = "https://device.griffon.adobe.com/device";
+        static final String BASE_DEVICE_API_URL_FORMAT =
+                "https://device%s.griffon.adobe.com/device";
         static final String DEVICE_API_PATH_CREATE = "create";
         static final String DEVICE_API_PATH_STATUS = "status";
         static final String KEY_SESSION_ID = "sessionUuid";

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceSessionOrchestrator.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceSessionOrchestrator.java
@@ -23,6 +23,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import com.adobe.marketing.mobile.Assurance;
 import com.adobe.marketing.mobile.services.Log;
+import com.adobe.marketing.mobile.services.NamedCollection;
 import com.adobe.marketing.mobile.services.ServiceProvider;
 import com.adobe.marketing.mobile.util.StringUtils;
 import java.lang.ref.WeakReference;
@@ -116,9 +117,20 @@ class AssuranceSessionOrchestrator {
                         }
                     }
 
+                    final NamedCollection assurancePreferenceStore =
+                            ServiceProvider.getInstance()
+                                    .getDataStoreService()
+                                    .getNamedCollection(
+                                            AssuranceConstants.DataStoreKeys.DATASTORE_NAME);
+                    final String environment =
+                            assurancePreferenceStore == null
+                                    ? null
+                                    : assurancePreferenceStore.getString(
+                                            AssuranceConstants.DataStoreKeys.ENVIRONMENT, "");
+
                     createSession(
                             sessionId,
-                            AssuranceConstants.AssuranceEnvironment.PROD,
+                            AssuranceConstants.AssuranceEnvironment.get(environment),
                             token,
                             listener,
                             SessionAuthorizingPresentation.Type.QUICK_CONNECT);

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/QuickConnectDeviceCreator.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/QuickConnectDeviceCreator.kt
@@ -31,12 +31,14 @@ import javax.net.ssl.HttpsURLConnection
  * @param orgId orgId that was used for the the device creation/registration
  * @param clientId clientId to be used for the the device creation/registration
  * @param deviceName deviceName to be used for the the device creation/registration
+ * @param environment environment to be used for the the device creation/registration
  * @param callback a callback that will be used to be notify of the response to the network request
  */
 internal class QuickConnectDeviceCreator(
     private val orgId: String,
     private val clientId: String,
     private val deviceName: String,
+    private val environment: String = "",
     private val callback: AdobeCallback<Response<HttpConnecting, AssuranceConnectionError>>
 ) : Runnable {
 
@@ -64,8 +66,8 @@ internal class QuickConnectDeviceCreator(
      * Builds the network request for creating device.
      */
     private fun buildRequest(): NetworkRequest {
-        val url =
-            "${QuickConnect.BASE_DEVICE_API_URL}/${QuickConnect.DEVICE_API_PATH_CREATE}"
+        val prefixedEnv = if (environment.isNotEmpty()) "-$environment" else ""
+        val url = "${String.format(QuickConnect.BASE_DEVICE_API_URL_FORMAT, prefixedEnv)}/${QuickConnect.DEVICE_API_PATH_CREATE}"
 
         val headers: Map<String, String> = mapOf(
             NetworkingConstants.Headers.ACCEPT to NetworkingConstants.HeaderValues.CONTENT_TYPE_JSON_APPLICATION,

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/QuickConnectDeviceStatusChecker.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/QuickConnectDeviceStatusChecker.kt
@@ -31,11 +31,13 @@ import javax.net.ssl.HttpsURLConnection
  *
  * @param orgId orgId that was used for the the device creation/registration
  * @param clientId clientId that was used for the the device creation/registration
+ * @param environment environment that was used for the the device creation/registration
  * @param callback a callback to be notified of the response to the network request
  */
 internal class QuickConnectDeviceStatusChecker(
     private val orgId: String,
     private val clientId: String,
+    private val environment: String = "",
     private val callback: AdobeCallback<Response<HttpConnecting, AssuranceConnectionError>>
 ) : Runnable {
 
@@ -63,7 +65,8 @@ internal class QuickConnectDeviceStatusChecker(
      * Builds the network request for checking the status of device creation.
      */
     private fun buildRequest(): NetworkRequest {
-        val url = "${QuickConnect.BASE_DEVICE_API_URL}/${QuickConnect.DEVICE_API_PATH_STATUS}"
+        val prefixedEnv = if (environment.isNotEmpty()) "-$environment" else ""
+        val url = "${String.format(QuickConnect.BASE_DEVICE_API_URL_FORMAT, prefixedEnv)}/${QuickConnect.DEVICE_API_PATH_STATUS}"
 
         val body: Map<String, String> = mapOf(
             QuickConnect.KEY_ORG_ID to orgId,

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceSessionOrchestratorTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceSessionOrchestratorTest.java
@@ -22,8 +22,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Application;
+import com.adobe.marketing.mobile.services.DataStoring;
+import com.adobe.marketing.mobile.services.NamedCollection;
+import com.adobe.marketing.mobile.services.ServiceProvider;
 import java.util.Collections;
 import java.util.List;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,6 +35,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
@@ -48,9 +53,14 @@ public class AssuranceSessionOrchestratorTest {
     @Mock private AssuranceConnectionDataStore mockAssuranceConnectionDataStore;
     @Mock private AssuranceSessionOrchestrator.AssuranceSessionCreator mockAssuranceSessionCreator;
     @Mock private AssuranceSession mockAssuranceSession;
+    @Mock private ServiceProvider mockServiceProvider;
+    @Mock private DataStoring mockDataStoreService;
+    @Mock private NamedCollection mockNamedCollection;
 
     @Mock
     private AssuranceSession.AssuranceSessionStatusListener mockAuthorizingPresentationListener;
+
+    private MockedStatic<ServiceProvider> mockedStaticServiceProvider;
 
     private AssuranceSessionOrchestrator.HostAppActivityLifecycleObserver
             hostAppActivityLifecycleObserver;
@@ -60,6 +70,14 @@ public class AssuranceSessionOrchestratorTest {
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
+
+        mockedStaticServiceProvider = Mockito.mockStatic(ServiceProvider.class);
+        mockedStaticServiceProvider
+                .when(ServiceProvider::getInstance)
+                .thenReturn(mockServiceProvider);
+
+        when(mockServiceProvider.getDataStoreService()).thenReturn(mockDataStoreService);
+        when(mockDataStoreService.getNamedCollection(anyString())).thenReturn(mockNamedCollection);
 
         assuranceSessionOrchestrator =
                 new AssuranceSessionOrchestrator(
@@ -483,5 +501,10 @@ public class AssuranceSessionOrchestratorTest {
                 .registerStatusListener(
                         assuranceSessionOrchestrator.getAssuranceSessionStatusListener());
         verify(mockAssuranceStateManager).shareAssuranceSharedState("SessionID");
+    }
+
+    @After
+    public void tearDown() {
+        mockedStaticServiceProvider.close();
     }
 }

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/QuickConnectDeviceCreatorTest.kt
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/QuickConnectDeviceCreatorTest.kt
@@ -58,6 +58,7 @@ class QuickConnectDeviceCreatorTest {
     private lateinit var mockCallback: AdobeCallback<Response<HttpConnecting, AssuranceConnectionError>>
 
     private lateinit var mockedStaticServiceProvider: MockedStatic<ServiceProvider>
+    private var environment: String = ""
 
     @Before
     fun setUp() {
@@ -70,7 +71,7 @@ class QuickConnectDeviceCreatorTest {
     @Test
     fun `Verify DeviceCreationTask makes network request`() {
         // setup
-        val quickConnectDeviceCreator = QuickConnectDeviceCreator(TEST_ORG_ID, TEST_CLIENT_ID, TEST_DEVICE_NAME, mockCallback)
+        val quickConnectDeviceCreator = QuickConnectDeviceCreator(TEST_ORG_ID, TEST_CLIENT_ID, TEST_DEVICE_NAME, environment, mockCallback)
 
         // test
         quickConnectDeviceCreator.run()
@@ -92,7 +93,7 @@ class QuickConnectDeviceCreatorTest {
         ).toString().toByteArray()
 
         val expectedNetworkRequest = NetworkRequest(
-            "${QuickConnect.BASE_DEVICE_API_URL}/${QuickConnect.DEVICE_API_PATH_CREATE}",
+            "${getBaseUrl(environment)}/${QuickConnect.DEVICE_API_PATH_CREATE}",
             HttpMethod.POST,
             expectedBody,
             mapOf(
@@ -112,7 +113,7 @@ class QuickConnectDeviceCreatorTest {
     @Test
     fun `Verify DeviceCreationTask invoked callback with Success response when request successful`() {
         // setup
-        val quickConnectDeviceCreator = QuickConnectDeviceCreator(TEST_ORG_ID, TEST_CLIENT_ID, TEST_DEVICE_NAME, mockCallback)
+        val quickConnectDeviceCreator = QuickConnectDeviceCreator(TEST_ORG_ID, TEST_CLIENT_ID, TEST_DEVICE_NAME, environment, mockCallback)
 
         // test
         quickConnectDeviceCreator.run()
@@ -134,7 +135,7 @@ class QuickConnectDeviceCreatorTest {
         ).toString().toByteArray()
 
         val expectedNetworkRequest = NetworkRequest(
-            "${QuickConnect.BASE_DEVICE_API_URL}/${QuickConnect.DEVICE_API_PATH_CREATE}",
+            "${getBaseUrl(environment)}/${QuickConnect.DEVICE_API_PATH_CREATE}",
             HttpMethod.POST,
             expectedBody,
             mapOf(
@@ -171,7 +172,7 @@ class QuickConnectDeviceCreatorTest {
     @Test
     fun `Verify DeviceCreationTask invoked callback with CREATE_DEVICE_REQUEST_FAILED response when request fails`() {
         // setup
-        val quickConnectDeviceCreator = QuickConnectDeviceCreator(TEST_ORG_ID, TEST_CLIENT_ID, TEST_DEVICE_NAME, mockCallback)
+        val quickConnectDeviceCreator = QuickConnectDeviceCreator(TEST_ORG_ID, TEST_CLIENT_ID, TEST_DEVICE_NAME, environment, mockCallback)
 
         // test
         quickConnectDeviceCreator.run()
@@ -193,7 +194,7 @@ class QuickConnectDeviceCreatorTest {
         ).toString().toByteArray()
 
         val expectedNetworkRequest = NetworkRequest(
-            "${QuickConnect.BASE_DEVICE_API_URL}/${QuickConnect.DEVICE_API_PATH_CREATE}",
+            "${getBaseUrl(environment)}/${QuickConnect.DEVICE_API_PATH_CREATE}",
             HttpMethod.POST,
             expectedBody,
             mapOf(
@@ -230,7 +231,7 @@ class QuickConnectDeviceCreatorTest {
     @Test
     fun `Verify DeviceCreationTask invoked callback with UNEXPECTED_ERROR response when request fails`() {
         // setup
-        val quickConnectDeviceCreator = QuickConnectDeviceCreator(TEST_ORG_ID, TEST_CLIENT_ID, TEST_DEVICE_NAME, mockCallback)
+        val quickConnectDeviceCreator = QuickConnectDeviceCreator(TEST_ORG_ID, TEST_CLIENT_ID, TEST_DEVICE_NAME, environment, mockCallback)
 
         // test
         quickConnectDeviceCreator.run()
@@ -252,7 +253,7 @@ class QuickConnectDeviceCreatorTest {
         ).toString().toByteArray()
 
         val expectedNetworkRequest = NetworkRequest(
-            "${QuickConnect.BASE_DEVICE_API_URL}/${QuickConnect.DEVICE_API_PATH_CREATE}",
+            "${String.format(QuickConnect.BASE_DEVICE_API_URL_FORMAT, "")}/${QuickConnect.DEVICE_API_PATH_CREATE}",
             HttpMethod.POST,
             expectedBody,
             mapOf(
@@ -283,8 +284,53 @@ class QuickConnectDeviceCreatorTest {
         }
     }
 
+    @Test
+    fun `Test that QuickConnectDeviceCreator honours environment`() {
+        // setup
+        environment = "stage"
+        val quickConnectDeviceCreator = QuickConnectDeviceCreator(TEST_ORG_ID, TEST_CLIENT_ID, TEST_DEVICE_NAME, environment, mockCallback)
+
+        // test
+        quickConnectDeviceCreator.run()
+
+        // Verify
+        val networkRequestCaptor: KArgumentCaptor<NetworkRequest> = argumentCaptor()
+        val networkCallbackCaptor: KArgumentCaptor<NetworkCallback> = argumentCaptor()
+        verify(mockNetworkService).connectAsync(networkRequestCaptor.capture(), networkCallbackCaptor.capture())
+
+        val capturedNetworkRequest = networkRequestCaptor.firstValue
+        assertNotNull(capturedNetworkRequest)
+
+        val expectedBody = JSONObject(
+            mapOf(
+                QuickConnect.KEY_ORG_ID to TEST_ORG_ID,
+                QuickConnect.KEY_DEVICE_NAME to TEST_DEVICE_NAME,
+                QuickConnect.KEY_CLIENT_ID to TEST_CLIENT_ID
+            )
+        ).toString().toByteArray()
+
+        val expectedNetworkRequest = NetworkRequest(
+            "${getBaseUrl(environment)}/${QuickConnect.DEVICE_API_PATH_CREATE}",
+            HttpMethod.POST,
+            expectedBody,
+            mapOf(
+                NetworkingConstants.Headers.ACCEPT to NetworkingConstants.HeaderValues.CONTENT_TYPE_JSON_APPLICATION,
+                NetworkingConstants.Headers.CONTENT_TYPE to NetworkingConstants.HeaderValues.CONTENT_TYPE_JSON_APPLICATION
+            ),
+            QuickConnect.CONNECTION_TIMEOUT_MS,
+            QuickConnect.READ_TIMEOUT_MS
+        )
+
+        verifyNetworkRequestParams(expectedNetworkRequest, capturedNetworkRequest)
+    }
+
     @After
     fun teardown() {
         mockedStaticServiceProvider.close()
+    }
+
+    private fun getBaseUrl(environment: String): String {
+        val prefixedEnv = if (environment.isNotEmpty()) "-$environment" else ""
+        return String.format(QuickConnect.BASE_DEVICE_API_URL_FORMAT, prefixedEnv)
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There are use-cases where Quick Connect is required to connect to a non-prod environment. Allow environment retrieval from shared preferences for this purpose.
<!--- Describe your changes in detail -->

## Related Issue
Internal - MOB-19328

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
There are use-cases where Quick Connect is required to connect to a non-prod environment. Allow environment retrieval from shared preferences for this purpose.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Manual tests
- Unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.