### PR TITLE
Avoid parsing Manifest repeatedly

### DIFF
--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceClientInfo.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceClientInfo.java
@@ -31,12 +31,22 @@ import com.adobe.marketing.mobile.services.ServiceProvider;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import org.json.JSONObject;
 
 final class AssuranceClientInfo {
 
     private static final String VALUE_UNKNOWN = "Unknown";
     private static final String MANIFEST_FILE_NAME = "AndroidManifest.xml";
     private static final String EVENT_TYPE_CONNECT = "connect";
+
+    private final JSONObject manifestData;
+
+    AssuranceClientInfo() {
+        // parse the manifest file and store it in a JSONObject for later use as this does not
+        // change
+        // during the lifetime of the application
+        manifestData = AssuranceIOUtils.parseXMLResourceFileToJson(MANIFEST_FILE_NAME);
+    }
 
     /**
      * Returns the payload for assurance ClientInfo event. ClientInfo event includes
@@ -57,9 +67,7 @@ final class AssuranceClientInfo {
         eventPayload.put(AssuranceConstants.ClientInfoKeys.VERSION, Assurance.extensionVersion());
         eventPayload.put(AssuranceConstants.ClientInfoKeys.DEVICE_INFO, getDeviceInfo());
         eventPayload.put(AssuranceConstants.PayloadDataKeys.TYPE, EVENT_TYPE_CONNECT);
-        eventPayload.put(
-                AssuranceConstants.ClientInfoKeys.APP_SETTINGS,
-                AssuranceIOUtils.parseXMLResourceFileToJson(MANIFEST_FILE_NAME));
+        eventPayload.put(AssuranceConstants.ClientInfoKeys.APP_SETTINGS, manifestData);
         return eventPayload;
     }
 

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceClientInfoTest.java
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/AssuranceClientInfoTest.java
@@ -65,22 +65,26 @@ public class AssuranceClientInfoTest {
     private MockedStatic<ServiceProvider> mockedStaticServiceProvider;
     private MockedStatic<ActivityCompat> mockedStaticActivityCompat;
 
+    private JSONObject appSettings;
+
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.openMocks(this);
-        assuranceClientInfo = new AssuranceClientInfo();
+
         mockedStaticActivityCompat = Mockito.mockStatic(ActivityCompat.class);
         mockedStaticAssuranceIOUtils = Mockito.mockStatic(AssuranceIOUtils.class);
         mockedStaticServiceProvider = Mockito.mockStatic(ServiceProvider.class);
-    }
 
-    @Test
-    public void testGetData_happy() throws JSONException {
-        final JSONObject appSettings = mockManifestData();
+        appSettings = mockManifestData();
         mockedStaticAssuranceIOUtils
                 .when(() -> AssuranceIOUtils.parseXMLResourceFileToJson(any()))
                 .thenReturn(appSettings);
 
+        assuranceClientInfo = new AssuranceClientInfo();
+    }
+
+    @Test
+    public void testGetData_happy() throws JSONException {
         mockAppContextService();
         mockTelephonyManager("MyNetworkCarrier");
         mockBatteryLevel(95);
@@ -115,11 +119,6 @@ public class AssuranceClientInfoTest {
 
     @Test
     public void testGetData_locationAuthorizationDenied() throws JSONException {
-        final JSONObject appSettings = mockManifestData();
-        mockedStaticAssuranceIOUtils
-                .when(() -> AssuranceIOUtils.parseXMLResourceFileToJson(any()))
-                .thenReturn(appSettings);
-
         mockAppContextService();
         mockTelephonyManager("MyNetworkCarrier");
         mockBatteryLevel(95);
@@ -154,11 +153,6 @@ public class AssuranceClientInfoTest {
 
     @Test
     public void testGetData_lowPowerModeEnabled() throws JSONException {
-        final JSONObject appSettings = mockManifestData();
-        mockedStaticAssuranceIOUtils
-                .when(() -> AssuranceIOUtils.parseXMLResourceFileToJson(any()))
-                .thenReturn(appSettings);
-
         mockAppContextService();
         mockTelephonyManager("MyNetworkCarrier");
         mockBatteryLevel(95);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Assurance upon connection sends the parsed manifest as part of the clientInfo event. This is being done on the WebView thread and also the manifest is being parsed everytime this event is sent.
- Parsing the manifest from java bridge thread is resulting in the webview manifest being returned sometimes. Switch manifest parsing to the worker thread.
- Avoid parsing the manifest repeatedly as it does not change during app runtime. Do it once during session creation.

<!--- Describe your changes in detail -->

## Related Issue
N/A
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
- Assurance upon connection/re-connection, sends the parsed manifest as part of the clientInfo event.  The manifest is being parsed every time this event is sent. But this is redundant as the manifest does not change during app runtime. 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- unit tests
- manual tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.