### PR TITLE
Fix QuickConnect alignments and launch condition

### DIFF
--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceExtension.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/AssuranceExtension.java
@@ -16,7 +16,6 @@ import static com.adobe.marketing.mobile.assurance.AssuranceConstants.PayloadDat
 import static com.adobe.marketing.mobile.assurance.AssuranceConstants.PayloadDataKeys.XDM_STATE_DATA;
 import static com.adobe.marketing.mobile.assurance.AssuranceConstants.SDKEventName.XDM_SHARED_STATE_CHANGE;
 
-import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
 import android.content.Intent;
@@ -223,13 +222,6 @@ public final class AssuranceExtension extends Extension {
                     Assurance.LOG_TAG,
                     LOG_TAG,
                     "startSession() API is available only on debug builds.");
-            return;
-        }
-
-        final Activity currentActivity =
-                ServiceProvider.getInstance().getAppContextService().getCurrentActivity();
-        if (currentActivity == null) {
-            Log.debug(Assurance.LOG_TAG, LOG_TAG, "No foreground activity to launch quick flow.");
             return;
         }
 

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/ActionButtonRow.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/ActionButtonRow.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
@@ -52,7 +53,8 @@ internal fun ActionButtonRow(
                 horizontal = AssuranceTheme.dimensions.padding.small,
                 vertical = AssuranceTheme.dimensions.padding.medium
             ),
-        horizontalArrangement = Arrangement.SpaceEvenly
+        horizontalArrangement = Arrangement.SpaceEvenly,
+        verticalAlignment = Alignment.CenterVertically
     ) {
         // Cancel button
         OutlinedButton(

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectView.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectView.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -27,6 +28,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.adobe.marketing.mobile.assurance.R
 import com.adobe.marketing.mobile.assurance.internal.ui.AssuranceUiTestTags
 import com.adobe.marketing.mobile.assurance.internal.ui.common.AssuranceHeader
@@ -94,11 +96,11 @@ internal fun QuickConnectView(
             contentDescription = "Adobe Logo",
             contentScale = ContentScale.Inside,
             modifier = Modifier
+                .height(20.dp)
                 .fillMaxWidth()
                 .align(Alignment.BottomCenter)
                 .padding(
-                    horizontal = AssuranceTheme.dimensions.padding.medium,
-                    vertical = AssuranceTheme.dimensions.padding.xLarge
+                    bottom = AssuranceTheme.dimensions.padding.xSmall
                 )
                 .testTag(AssuranceUiTestTags.QuickConnectScreen.ADOBE_LOGO)
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- QuickConnect can be launched directly from the main application `onCreate()` so it uses the host application to launch the QuickConnect activity directly. So it is unnecessary to check for null of the current activity.
- QuickConnect action button alignment needs to be centered vertically to prevent the buttons being at different levels.
- Restrict the height of the adobe logo image to ensure that it is not very large in smaller screens

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
- QuickConnect can be launched directly from the main application `onCreate()` so it uses the host application to launch the QuickConnect activity directly. So it is unnecessary to check for null of the current activity.
- QuickConnect action button alignment needs to be centered vertically to prevent the buttons being at different levels.
- Restrict the height of the adobe logo image to ensure that it is not very large in smaller screens

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Manually verify alignment of buttons
- Manually verify launching QuickConnect from `application.onCreate()`.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.