### PR TITLE
Standardize PinScreen dimensions and theming

### DIFF
--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/error/AssuranceErrorScreen.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/error/AssuranceErrorScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.adobe.marketing.mobile.assurance.R
 import com.adobe.marketing.mobile.assurance.internal.AssuranceConstants
@@ -50,11 +49,11 @@ internal fun AssuranceErrorScreen(assuranceConnectionError: AssuranceConstants.A
         modifier = Modifier
             .fillMaxSize()
             .background(AssuranceTheme.backgroundColor)
-            .padding(horizontal = 32.dp)
+            .padding(horizontal = AssuranceTheme.dimensions.padding.xLarge)
     ) {
         Column(
             modifier = Modifier.fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(24.dp)
+            verticalArrangement = Arrangement.spacedBy(AssuranceTheme.dimensions.spacing.medium)
         ) {
             AssuranceHeader()
 

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/DialPadView.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/DialPadView.kt
@@ -24,13 +24,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import com.adobe.marketing.mobile.assurance.R
 import com.adobe.marketing.mobile.assurance.internal.ui.AssuranceUiTestTags
 import com.adobe.marketing.mobile.assurance.internal.ui.common.AssuranceHeader
 import com.adobe.marketing.mobile.assurance.internal.ui.common.AssuranceSubHeader
 import com.adobe.marketing.mobile.assurance.internal.ui.pin.PinScreenAction
 import com.adobe.marketing.mobile.assurance.internal.ui.pin.PinScreenState
+import com.adobe.marketing.mobile.assurance.internal.ui.theme.AssuranceTheme
 import com.adobe.marketing.mobile.assurance.internal.ui.theme.AssuranceTheme.backgroundColor
 
 /**
@@ -48,12 +48,12 @@ internal fun DialPadView(
         modifier = Modifier
             .fillMaxSize()
             .background(backgroundColor)
-            .padding(horizontal = 64.dp)
+            .padding(horizontal = AssuranceTheme.dimensions.padding.xxLarge)
             .testTag(AssuranceUiTestTags.PinScreen.DIAL_PAD_VIEW)
     ) {
         Column(
             modifier = Modifier.fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(24.dp)
+            verticalArrangement = Arrangement.spacedBy(AssuranceTheme.dimensions.spacing.medium)
         ) {
             AssuranceHeader()
             AssuranceSubHeader(text = stringResource(id = R.string.pin_connect_enter_pin_text))
@@ -68,7 +68,7 @@ internal fun DialPadView(
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.BottomStart)
-                .padding(bottom = 20.dp),
+                .padding(bottom = AssuranceTheme.dimensions.padding.medium),
             pinScreenState = pinScreenState,
             onAction = { action -> onAction(action) }
         )

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/InputFeedbackRow.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/InputFeedbackRow.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.adobe.marketing.mobile.assurance.internal.ui.AssuranceUiTestTags
+import com.adobe.marketing.mobile.assurance.internal.ui.theme.AssuranceTheme
 
 /**
  * Displays the input feedback for the pin entered using the pinpad.
@@ -71,7 +72,10 @@ private fun CharHolder(character: Char) {
         text = character.toString(),
         modifier = Modifier
             .width(48.dp)
-            .padding(vertical = 8.dp, horizontal = 4.dp)
+            .padding(
+                vertical = AssuranceTheme.dimensions.padding.small,
+                horizontal = AssuranceTheme.dimensions.padding.xSmall
+            )
             .background(Color.Transparent)
             .drawBehind {
                 drawLine(

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/NumberRow.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/NumberRow.kt
@@ -21,10 +21,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.adobe.marketing.mobile.assurance.internal.ui.AssuranceUiTestTags
 import com.adobe.marketing.mobile.assurance.internal.ui.pin.PinScreenAction
+import com.adobe.marketing.mobile.assurance.internal.ui.theme.AssuranceTheme
 
 /**
  * A row of dial pad buttons that are digits.
@@ -37,7 +37,7 @@ internal fun NumberRow(contents: List<String>, onClick: (PinScreenAction) -> Uni
         modifier = Modifier
             .fillMaxWidth()
             .testTag(AssuranceUiTestTags.PinScreen.NUMBER_ROW),
-        horizontalArrangement = Arrangement.spacedBy(20.dp)
+        horizontalArrangement = Arrangement.spacedBy(AssuranceTheme.dimensions.spacing.small)
     ) {
         contents.forEach { symbol ->
             DialPadButton(

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/SymbolRow.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/SymbolRow.kt
@@ -27,10 +27,10 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.adobe.marketing.mobile.assurance.internal.ui.AssuranceUiTestTags
 import com.adobe.marketing.mobile.assurance.internal.ui.pin.PinScreenAction
+import com.adobe.marketing.mobile.assurance.internal.ui.theme.AssuranceTheme
 import com.adobe.marketing.mobile.util.StreamUtils
 
 /**
@@ -43,7 +43,7 @@ internal fun SymbolRow(onClick: (PinScreenAction) -> Unit) {
     Row(
         modifier = Modifier.fillMaxWidth()
             .testTag(AssuranceUiTestTags.PinScreen.SYMBOL_ROW),
-        horizontalArrangement = Arrangement.spacedBy(20.dp)
+        horizontalArrangement = Arrangement.spacedBy(AssuranceTheme.dimensions.spacing.small)
     ) {
         // Intentionally empty content button for filling the grid evenly
         DialPadButton(

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/error/PinAuthErrorMessageContent.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/error/PinAuthErrorMessageContent.kt
@@ -26,9 +26,9 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.adobe.marketing.mobile.assurance.internal.ui.AssuranceUiTestTags
+import com.adobe.marketing.mobile.assurance.internal.ui.theme.AssuranceTheme
 
 /**
  * Displays the content of the error message in the pin authorization flow.
@@ -52,7 +52,7 @@ internal fun PinAuthErrorMessageContent(text: String) {
             modifier = Modifier
                 .fillMaxWidth()
                 .wrapContentSize(Alignment.Center)
-                .padding(bottom = 4.dp)
+                .padding(bottom = AssuranceTheme.dimensions.padding.xSmall)
                 .testTag(AssuranceUiTestTags.PinScreen.PIN_ERROR_CONTENT)
         )
     }

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/error/PinErrorView.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/error/PinErrorView.kt
@@ -22,11 +22,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.unit.dp
 import com.adobe.marketing.mobile.assurance.internal.AssuranceConstants.AssuranceConnectionError
 import com.adobe.marketing.mobile.assurance.internal.ui.AssuranceUiTestTags
 import com.adobe.marketing.mobile.assurance.internal.ui.common.AssuranceHeader
 import com.adobe.marketing.mobile.assurance.internal.ui.pin.PinScreenAction
+import com.adobe.marketing.mobile.assurance.internal.ui.theme.AssuranceTheme
 import com.adobe.marketing.mobile.assurance.internal.ui.theme.AssuranceTheme.backgroundColor
 
 /**
@@ -45,12 +45,12 @@ internal fun PinErrorView(
         modifier = Modifier
             .fillMaxSize()
             .background(backgroundColor)
-            .padding(horizontal = 32.dp)
             .testTag(AssuranceUiTestTags.PinScreen.PIN_ERROR_VIEW)
     ) {
         Column(
-            modifier = Modifier.fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(24.dp)
+            modifier = Modifier.fillMaxSize()
+                .padding(horizontal = AssuranceTheme.dimensions.padding.xLarge),
+            verticalArrangement = Arrangement.spacedBy(AssuranceTheme.dimensions.spacing.medium)
         ) {
             AssuranceHeader()
             PinAuthErrorMessageHeader(text = assuranceConnectionError.error)
@@ -61,7 +61,11 @@ internal fun PinErrorView(
             modifier = Modifier
                 .fillMaxWidth()
                 .align(Alignment.BottomStart)
-                .padding(bottom = 20.dp)
+                .padding(
+                    bottom = AssuranceTheme.dimensions.padding.medium,
+                    start = AssuranceTheme.dimensions.padding.xxLarge,
+                    end = AssuranceTheme.dimensions.padding.xxLarge
+                )
                 .testTag(AssuranceUiTestTags.PinScreen.PIN_ERROR_ACTION_BUTTON_ROW),
             error = assuranceConnectionError,
             onAction = { action -> onAction(action) }

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/loading/PinConnectingView.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/loading/PinConnectingView.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.adobe.marketing.mobile.assurance.internal.ui.common.AssuranceHeader
+import com.adobe.marketing.mobile.assurance.internal.ui.theme.AssuranceTheme
 import com.adobe.marketing.mobile.assurance.internal.ui.theme.AssuranceTheme.backgroundColor
 
 /**
@@ -36,12 +37,12 @@ internal fun PinConnectingView() {
         modifier = Modifier.run {
             fillMaxSize()
                 .background(backgroundColor)
-                .padding(horizontal = 32.dp)
+                .padding(horizontal = AssuranceTheme.dimensions.padding.xLarge)
         }
     ) {
         Column(
             modifier = Modifier.fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(24.dp),
+            verticalArrangement = Arrangement.spacedBy(AssuranceTheme.dimensions.spacing.medium),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             AssuranceHeader()


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
`AssuranceTheme.dimensions` was introduced as part of QuickConnect screen migration. Apply the constants to PinScreen:
- Use AssuranceTheme.dimensions for specifying dimensions
- Ensure text padding of PinErrorView matches iOS

## How Has This Been Tested?
- Manual verification of PinFlow looks wrt iOS and Android 2.x

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.