### PR TITLE
Terminate status jobs when quick connect is cancelled

### DIFF
--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectViewModel.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectViewModel.kt
@@ -134,6 +134,7 @@ internal class QuickConnectViewModel : ViewModel {
         when (quickConnectScreenAction) {
             is QuickConnectScreenAction.Cancel -> {
                 _state.value = ConnectionState.Disconnected(null)
+                quickConnectManager.cancel()
                 AssuranceComponentRegistry.sessionUIOperationHandler?.onCancel()
             }
 

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectViewModelTest.kt
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectViewModelTest.kt
@@ -91,6 +91,7 @@ class QuickConnectViewModelTest {
             ConnectionState.Disconnected(null),
             quickConnectViewModel.state.value
         )
+        verify(mockQuickConnectManager).cancel()
         verify(mockSessionUIOperationHandler).onCancel()
     }
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, the device status check job is not being cancelled when the 'Cancel' button is clicked before the QuickConnect status check succeeds. This was a miss when porting from 2.x. While this is a usual case, it is still possible to Cancel the flow when waiting.

As a solution invoke QuickConnectManager.cancel() when Cancel is clicked.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Currently, the device status check job is not being cancelled when the 'Cancel' button is clicked before the QuickConnect status check succeeds. This was a miss when porting from 2.x. While this is a not a usual case, it is still possible to Cancel the flow when waiting. 
As a solution invoke QuickConnectManager.cancel() when Cancel is clicked.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Unit tests
- Manual tests using assurance test app.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.