### PR TITLE
Make QuickConnect Authorization environment aware for test/development purposes

### DIFF
--- a/.github/workflows/update-testapp.yml
+++ b/.github/workflows/update-testapp.yml
@@ -12,10 +12,12 @@ jobs:
     runs-on: macos-latest
 
     steps:
+
     - name: Set up Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
-        java-version: 11
+        distribution: 'zulu'
+        java-version: 17
 
     - name: Checkout
       uses: actions/checkout@v3.1.0

--- a/code/assurance-testapp/build.gradle.kts
+++ b/code/assurance-testapp/build.gradle.kts
@@ -86,15 +86,9 @@ android {
         implementation("com.adobe.marketing.mobile:lifecycle:3.0.0")
         // Messaging, Edge, and EdgeIdentity will be available after Core, Assurance release.
         // Use Snapshot version for initial Assurance release.
-        implementation("com.adobe.marketing.mobile:messaging:3.0.0-beta.1-SNAPSHOT") {
-            isTransitive = false
-        }
-        implementation("com.adobe.marketing.mobile:edge:3.0.0-beta.1-SNAPSHOT") {
-            isTransitive = false
-        }
-        implementation("com.adobe.marketing.mobile:edgeidentity:3.0.0-beta.1-SNAPSHOT") {
-            isTransitive = false
-        }
+        implementation("com.adobe.marketing.mobile:messaging:3.0.0")
+        implementation("com.adobe.marketing.mobile:edge:3.0.0")
+        implementation("com.adobe.marketing.mobile:edgeidentity:3.0.0")
 
         testImplementation("junit:junit:4.13.2")
 

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/AssuranceConstants.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/AssuranceConstants.kt
@@ -215,7 +215,7 @@ internal object AssuranceConstants {
     }
 
     internal object QuickConnect {
-        const val BASE_DEVICE_API_URL = "https://device.griffon.adobe.com/device"
+        val BASE_DEVICE_API_URL_FORMAT = "https://device%s.griffon.adobe.com/device"
         const val DEVICE_API_PATH_CREATE = "create"
         const val DEVICE_API_PATH_STATUS = "status"
         const val KEY_SESSION_ID = "sessionUuid"

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/AssuranceExtension.java
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/AssuranceExtension.java
@@ -34,6 +34,7 @@ import com.adobe.marketing.mobile.SharedStateStatus;
 import com.adobe.marketing.mobile.assurance.internal.AssuranceConstants.GenericEventPayloadKey;
 import com.adobe.marketing.mobile.assurance.internal.ui.AssuranceActivity;
 import com.adobe.marketing.mobile.services.Log;
+import com.adobe.marketing.mobile.services.NamedCollection;
 import com.adobe.marketing.mobile.services.ServiceProvider;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.DataReaderException;
@@ -234,10 +235,20 @@ public final class AssuranceExtension extends Extension {
         }
 
         // Change the session state to Authorizing with QuickConnect authorization
+        final NamedCollection assurancePreferenceStore =
+                ServiceProvider.getInstance()
+                        .getDataStoreService()
+                        .getNamedCollection(AssuranceConstants.DataStoreKeys.DATASTORE_NAME);
+        final String environment =
+                assurancePreferenceStore == null
+                        ? ""
+                        : assurancePreferenceStore.getString(
+                                AssuranceConstants.DataStoreKeys.ENVIRONMENT, "");
+
         AssuranceComponentRegistry.appState.onSessionPhaseChange(
                 new AssuranceAppState.SessionPhase.Authorizing(
                         new AssuranceAppState.AssuranceAuthorization.QuickConnect(
-                                AssuranceEnvironment.PROD)));
+                                AssuranceEnvironment.get(environment))));
 
         // Launch the Assurance Activity
         final Intent intent = new Intent(hostApplication, AssuranceActivity.class);

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/AssuranceSessionPresentationManager.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/AssuranceSessionPresentationManager.kt
@@ -65,12 +65,17 @@ internal class AssuranceSessionPresentationManager {
     /** Shows the UI elements that are required when a session connection has been disconnected.  */
     @JvmName("onSessionDisconnected")
     internal fun onSessionDisconnected(closeCode: Int) {
+        // Remove the button from the UI on any disconnection. This is OK since
+        // 1. The button will be  re-added when the session is connected via (onSessionConnected) or
+        //    re-connected (onSessionReconnecting) again after an error.
+        // 2. The button is not shown anyway when the Assurance Authorization UI is active.
+        button.remove()
+
         val error = SocketCloseCode.toAssuranceConnectionError(closeCode)
         if (error == null) {
             AssuranceComponentRegistry.appState.onSessionPhaseChange(
                 AssuranceAppState.SessionPhase.Disconnected()
             )
-            button.remove()
             logLocalUI(
                 UILogColorVisibility.LOW,
                 "Assurance disconnected."
@@ -96,7 +101,11 @@ internal class AssuranceSessionPresentationManager {
      */
     @JvmName("onSessionReconnecting")
     internal fun onSessionReconnecting() {
-        button.updateGraphic(false)
+        button.apply {
+            show()
+            updateGraphic(connected = false)
+        }
+
         logLocalUI(
             UILogColorVisibility.HIGH,
             "Assurance disconnected, attempting to reconnect ..."

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/QuickConnectDeviceCreator.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/QuickConnectDeviceCreator.kt
@@ -37,6 +37,7 @@ internal class QuickConnectDeviceCreator(
     private val orgId: String,
     private val clientId: String,
     private val deviceName: String,
+    private val environment: String = "",
     private val callback: AdobeCallback<Response<HttpConnecting, AssuranceConnectionError>>
 ) : Runnable {
 
@@ -64,8 +65,8 @@ internal class QuickConnectDeviceCreator(
      * Builds the network request for creating device.
      */
     private fun buildRequest(): NetworkRequest {
-        val url =
-            "${QuickConnect.BASE_DEVICE_API_URL}/${QuickConnect.DEVICE_API_PATH_CREATE}"
+        val prefixedEnv = if (environment.isNotEmpty()) "-$environment" else ""
+        val url = "${String.format(QuickConnect.BASE_DEVICE_API_URL_FORMAT, prefixedEnv)}/${QuickConnect.DEVICE_API_PATH_CREATE}"
 
         val headers: Map<String, String> = mapOf(
             NetworkingConstants.Headers.ACCEPT to NetworkingConstants.HeaderValues.CONTENT_TYPE_JSON_APPLICATION,

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/QuickConnectDeviceStatusChecker.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/QuickConnectDeviceStatusChecker.kt
@@ -36,6 +36,7 @@ import javax.net.ssl.HttpsURLConnection
 internal class QuickConnectDeviceStatusChecker(
     private val orgId: String,
     private val clientId: String,
+    private val environment: String = "",
     private val callback: AdobeCallback<Response<HttpConnecting, AssuranceConnectionError>>
 ) : Runnable {
 
@@ -63,7 +64,8 @@ internal class QuickConnectDeviceStatusChecker(
      * Builds the network request for checking the status of device creation.
      */
     private fun buildRequest(): NetworkRequest {
-        val url = "${QuickConnect.BASE_DEVICE_API_URL}/${QuickConnect.DEVICE_API_PATH_STATUS}"
+        val prefixedEnv = if (environment.isNotEmpty()) "-$environment" else ""
+        val url = "${String.format(QuickConnect.BASE_DEVICE_API_URL_FORMAT, prefixedEnv)}/${QuickConnect.DEVICE_API_PATH_STATUS}"
 
         val body: Map<String, String> = mapOf(
             QuickConnect.KEY_ORG_ID to orgId,

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/QuickConnectManager.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/QuickConnectManager.kt
@@ -35,7 +35,8 @@ import java.util.concurrent.TimeUnit
 internal class QuickConnectManager(
     private val assuranceSharedStateManager: AssuranceStateManager,
     private val executorService: ScheduledExecutorService,
-    private val quickConnectCallback: QuickConnectCallback
+    private val quickConnectEnvironment: String = "",
+    private val quickConnectCallback: QuickConnectCallback,
 ) {
 
     companion object {
@@ -90,7 +91,7 @@ internal class QuickConnectManager(
         val deviceName = ServiceProvider.getInstance().deviceInfoService.deviceName
         Log.trace(LOG_TAG, LOG_SOURCE, "Attempting to register device with deviceName:$deviceName, orgId: $orgId, clientId: $clientId.")
 
-        val quickConnectDeviceCreator = QuickConnectDeviceCreator(orgId, clientId, deviceName) {
+        val quickConnectDeviceCreator = QuickConnectDeviceCreator(orgId, clientId, deviceName, quickConnectEnvironment) {
             when (it) {
                 is Response.Success -> checkDeviceStatus(orgId, clientId)
                 is Response.Failure -> {
@@ -111,7 +112,7 @@ internal class QuickConnectManager(
      */
     @VisibleForTesting
     internal fun checkDeviceStatus(orgId: String, clientId: String) {
-        val statusCheckerTask = QuickConnectDeviceStatusChecker(orgId, clientId) { response ->
+        val statusCheckerTask = QuickConnectDeviceStatusChecker(orgId, clientId, quickConnectEnvironment) { response ->
             handleStatusCheckResponse(orgId, clientId, response)
         }
 

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectViewModel.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectViewModel.kt
@@ -89,6 +89,7 @@ internal class QuickConnectViewModel : ViewModel {
         quickConnectManager = QuickConnectManager(
             assuranceStateManager,
             Executors.newSingleThreadScheduledExecutor(),
+            if (environment == AssuranceConstants.AssuranceEnvironment.PROD) "" else environment.stringValue,
             object : QuickConnectCallback {
                 override fun onError(error: AssuranceConstants.AssuranceConnectionError) {
                     state.value = ConnectionState.Disconnected(error)
@@ -105,7 +106,7 @@ internal class QuickConnectViewModel : ViewModel {
                 }
             }
         ),
-        environment = AssuranceConstants.AssuranceEnvironment.PROD
+        environment = environment
     )
 
     /**
@@ -133,6 +134,7 @@ internal class QuickConnectViewModel : ViewModel {
     internal fun onAction(quickConnectScreenAction: QuickConnectScreenAction) {
         when (quickConnectScreenAction) {
             is QuickConnectScreenAction.Cancel -> {
+                quickConnectManager.cancel()
                 _state.value = ConnectionState.Disconnected(null)
                 AssuranceComponentRegistry.sessionUIOperationHandler?.onCancel()
             }

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/internal/AssuranceExtensionTest.kt
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/internal/AssuranceExtensionTest.kt
@@ -26,6 +26,8 @@ import com.adobe.marketing.mobile.SharedStateResolution
 import com.adobe.marketing.mobile.SharedStateResult
 import com.adobe.marketing.mobile.SharedStateStatus
 import com.adobe.marketing.mobile.services.AppContextService
+import com.adobe.marketing.mobile.services.DataStoring
+import com.adobe.marketing.mobile.services.NamedCollection
 import com.adobe.marketing.mobile.services.ServiceProvider
 import org.junit.After
 import org.junit.Before
@@ -85,6 +87,12 @@ class AssuranceExtensionTest {
     @Mock
     private lateinit var mockSession: AssuranceSession
 
+    @Mock
+    private lateinit var mockDataStoring: DataStoring
+
+    @Mock
+    private lateinit var mockNamedCollection: NamedCollection
+
     private lateinit var mockedStaticServiceProvider: MockedStatic<ServiceProvider>
     private lateinit var mockedStaticMobileCore: MockedStatic<MobileCore>
     private lateinit var mockedStaticUri: MockedStatic<Uri>
@@ -112,6 +120,9 @@ class AssuranceExtensionTest {
 
         `when`(mockServiceProvider.appContextService).thenReturn(mockAppContextService)
         `when`(mockApplication.applicationContext).thenReturn(mockContext)
+        `when`(mockServiceProvider.dataStoreService).thenReturn(mockDataStoring)
+        `when`(mockDataStoring.getNamedCollection(AssuranceConstants.DataStoreKeys.DATASTORE_NAME)).thenReturn(mockNamedCollection)
+        `when`(mockNamedCollection.getString(AssuranceConstants.DataStoreKeys.ENVIRONMENT, "")).thenReturn("")
     }
 
     @Test

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/internal/AssuranceSessionPresentationManagerTest.kt
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/internal/AssuranceSessionPresentationManagerTest.kt
@@ -124,6 +124,9 @@ class AssuranceSessionPresentationManagerTest {
 
         // Verify
 
+        // Floating button should be removed on disconnection
+        verify(mockAssuranceFloatingButton).remove()
+
         // Session phase should remain in Authorizing phase because the UI is active
         assertEquals(
             AssuranceAppState.SessionPhase.Authorizing(credentials),
@@ -131,7 +134,6 @@ class AssuranceSessionPresentationManagerTest {
         )
 
         // no changes in ui elements
-        verify(mockAssuranceFloatingButton, never()).remove()
         verify(mockActivity, never()).startActivity(any())
     }
 
@@ -210,6 +212,7 @@ class AssuranceSessionPresentationManagerTest {
         assuranceSessionPresentationManager.onSessionReconnecting()
 
         // Verify
+        verify(mockAssuranceFloatingButton).show()
         verify(mockAssuranceFloatingButton).updateGraphic(false)
         val currentPhase = AssuranceComponentRegistry.appState.sessionPhase.value
         assertTrue { currentPhase is AssuranceAppState.SessionPhase.Disconnected }

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/internal/QuickConnectDeviceCreatorTest.kt
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/internal/QuickConnectDeviceCreatorTest.kt
@@ -58,6 +58,7 @@ class QuickConnectDeviceCreatorTest {
     private lateinit var mockCallback: AdobeCallback<Response<HttpConnecting, AssuranceConnectionError>>
 
     private lateinit var mockedStaticServiceProvider: MockedStatic<ServiceProvider>
+    private var environment: String = ""
 
     @Before
     fun setUp() {
@@ -70,7 +71,7 @@ class QuickConnectDeviceCreatorTest {
     @Test
     fun `Verify DeviceCreationTask makes network request`() {
         // setup
-        val quickConnectDeviceCreator = QuickConnectDeviceCreator(TEST_ORG_ID, TEST_CLIENT_ID, TEST_DEVICE_NAME, mockCallback)
+        val quickConnectDeviceCreator = QuickConnectDeviceCreator(TEST_ORG_ID, TEST_CLIENT_ID, TEST_DEVICE_NAME, environment, mockCallback)
 
         // test
         quickConnectDeviceCreator.run()
@@ -92,7 +93,7 @@ class QuickConnectDeviceCreatorTest {
         ).toString().toByteArray()
 
         val expectedNetworkRequest = NetworkRequest(
-            "${QuickConnect.BASE_DEVICE_API_URL}/${QuickConnect.DEVICE_API_PATH_CREATE}",
+            "${getBaseUrl(environment)}/${QuickConnect.DEVICE_API_PATH_CREATE}",
             HttpMethod.POST,
             expectedBody,
             mapOf(
@@ -112,7 +113,7 @@ class QuickConnectDeviceCreatorTest {
     @Test
     fun `Verify DeviceCreationTask invoked callback with Success response when request successful`() {
         // setup
-        val quickConnectDeviceCreator = QuickConnectDeviceCreator(TEST_ORG_ID, TEST_CLIENT_ID, TEST_DEVICE_NAME, mockCallback)
+        val quickConnectDeviceCreator = QuickConnectDeviceCreator(TEST_ORG_ID, TEST_CLIENT_ID, TEST_DEVICE_NAME, environment, mockCallback)
 
         // test
         quickConnectDeviceCreator.run()
@@ -134,7 +135,7 @@ class QuickConnectDeviceCreatorTest {
         ).toString().toByteArray()
 
         val expectedNetworkRequest = NetworkRequest(
-            "${QuickConnect.BASE_DEVICE_API_URL}/${QuickConnect.DEVICE_API_PATH_CREATE}",
+            "${getBaseUrl(environment)}/${QuickConnect.DEVICE_API_PATH_CREATE}",
             HttpMethod.POST,
             expectedBody,
             mapOf(
@@ -171,7 +172,7 @@ class QuickConnectDeviceCreatorTest {
     @Test
     fun `Verify DeviceCreationTask invoked callback with CREATE_DEVICE_REQUEST_FAILED response when request fails`() {
         // setup
-        val quickConnectDeviceCreator = QuickConnectDeviceCreator(TEST_ORG_ID, TEST_CLIENT_ID, TEST_DEVICE_NAME, mockCallback)
+        val quickConnectDeviceCreator = QuickConnectDeviceCreator(TEST_ORG_ID, TEST_CLIENT_ID, TEST_DEVICE_NAME, environment, mockCallback)
 
         // test
         quickConnectDeviceCreator.run()
@@ -193,7 +194,7 @@ class QuickConnectDeviceCreatorTest {
         ).toString().toByteArray()
 
         val expectedNetworkRequest = NetworkRequest(
-            "${QuickConnect.BASE_DEVICE_API_URL}/${QuickConnect.DEVICE_API_PATH_CREATE}",
+            "${getBaseUrl(environment)}/${QuickConnect.DEVICE_API_PATH_CREATE}",
             HttpMethod.POST,
             expectedBody,
             mapOf(
@@ -230,7 +231,7 @@ class QuickConnectDeviceCreatorTest {
     @Test
     fun `Verify DeviceCreationTask invoked callback with UNEXPECTED_ERROR response when request fails`() {
         // setup
-        val quickConnectDeviceCreator = QuickConnectDeviceCreator(TEST_ORG_ID, TEST_CLIENT_ID, TEST_DEVICE_NAME, mockCallback)
+        val quickConnectDeviceCreator = QuickConnectDeviceCreator(TEST_ORG_ID, TEST_CLIENT_ID, TEST_DEVICE_NAME, environment, mockCallback)
 
         // test
         quickConnectDeviceCreator.run()
@@ -252,7 +253,7 @@ class QuickConnectDeviceCreatorTest {
         ).toString().toByteArray()
 
         val expectedNetworkRequest = NetworkRequest(
-            "${QuickConnect.BASE_DEVICE_API_URL}/${QuickConnect.DEVICE_API_PATH_CREATE}",
+            "${getBaseUrl(environment)}/${QuickConnect.DEVICE_API_PATH_CREATE}",
             HttpMethod.POST,
             expectedBody,
             mapOf(
@@ -286,5 +287,10 @@ class QuickConnectDeviceCreatorTest {
     @After
     fun teardown() {
         mockedStaticServiceProvider.close()
+    }
+
+    private fun getBaseUrl(environment: String): String {
+        val prefixedEnv = if (environment.isNotEmpty()) "-$environment" else ""
+        return String.format(QuickConnect.BASE_DEVICE_API_URL_FORMAT, prefixedEnv)
     }
 }

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/internal/QuickConnectDeviceStatusCheckerTest.kt
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/internal/QuickConnectDeviceStatusCheckerTest.kt
@@ -55,6 +55,7 @@ class QuickConnectDeviceStatusCheckerTest {
     private lateinit var mockCallback: AdobeCallback<Response<HttpConnecting, AssuranceConstants.AssuranceConnectionError>>
 
     private lateinit var mockedStaticServiceProvider: MockedStatic<ServiceProvider>
+    private var environment: String = ""
 
     @Before
     fun setUp() {
@@ -68,7 +69,7 @@ class QuickConnectDeviceStatusCheckerTest {
     @Test
     fun `Verify DeviceStatusCheckerTask makes network request`() {
         // setup
-        val quickConnectDeviceStatusChecker = QuickConnectDeviceStatusChecker(TEST_ORG_ID, TEST_CLIENT_ID, mockCallback)
+        val quickConnectDeviceStatusChecker = QuickConnectDeviceStatusChecker(TEST_ORG_ID, TEST_CLIENT_ID, environment, mockCallback)
 
         // test
         quickConnectDeviceStatusChecker.run()
@@ -89,7 +90,7 @@ class QuickConnectDeviceStatusCheckerTest {
         ).toString().toByteArray()
 
         val expectedNetworkRequest = NetworkRequest(
-            "${QuickConnect.BASE_DEVICE_API_URL}/${QuickConnect.DEVICE_API_PATH_STATUS}",
+            "${getBaseUrl(environment)}/${QuickConnect.DEVICE_API_PATH_STATUS}",
             HttpMethod.POST,
             expectedBody,
             mapOf(
@@ -109,7 +110,7 @@ class QuickConnectDeviceStatusCheckerTest {
     @Test
     fun `Verify DeviceStatusCheckerTask invoked callback with Success response when request successful`() {
         // setup
-        val quickConnectDeviceStatusChecker = QuickConnectDeviceStatusChecker(TEST_ORG_ID, TEST_CLIENT_ID, mockCallback)
+        val quickConnectDeviceStatusChecker = QuickConnectDeviceStatusChecker(TEST_ORG_ID, TEST_CLIENT_ID, environment, mockCallback)
 
         // test
         quickConnectDeviceStatusChecker.run()
@@ -130,7 +131,7 @@ class QuickConnectDeviceStatusCheckerTest {
         ).toString().toByteArray()
 
         val expectedNetworkRequest = NetworkRequest(
-            "${QuickConnect.BASE_DEVICE_API_URL}/${QuickConnect.DEVICE_API_PATH_STATUS}",
+            "${getBaseUrl(environment)}/${QuickConnect.DEVICE_API_PATH_STATUS}",
             HttpMethod.POST,
             expectedBody,
             mapOf(
@@ -167,7 +168,7 @@ class QuickConnectDeviceStatusCheckerTest {
     @Test
     fun `Verify DeviceStatusCheckerTask invokes callback with DEVICE_STATUS_REQUEST_FAILED response when request fails`() {
         // setup
-        val quickConnectDeviceStatusChecker = QuickConnectDeviceStatusChecker(TEST_ORG_ID, TEST_CLIENT_ID, mockCallback)
+        val quickConnectDeviceStatusChecker = QuickConnectDeviceStatusChecker(TEST_ORG_ID, TEST_CLIENT_ID, environment, mockCallback)
 
         // test
         quickConnectDeviceStatusChecker.run()
@@ -188,7 +189,7 @@ class QuickConnectDeviceStatusCheckerTest {
         ).toString().toByteArray()
 
         val expectedNetworkRequest = NetworkRequest(
-            "${QuickConnect.BASE_DEVICE_API_URL}/${QuickConnect.DEVICE_API_PATH_STATUS}",
+            "${getBaseUrl(environment)}/${QuickConnect.DEVICE_API_PATH_STATUS}",
             HttpMethod.POST,
             expectedBody,
             mapOf(
@@ -225,7 +226,7 @@ class QuickConnectDeviceStatusCheckerTest {
     @Test
     fun `Verify DeviceStatusCheckerTask invokes callback with UNEXPECTED_ERROR response when request fails`() {
         // setup
-        val quickConnectDeviceStatusChecker = QuickConnectDeviceStatusChecker(TEST_ORG_ID, TEST_CLIENT_ID, mockCallback)
+        val quickConnectDeviceStatusChecker = QuickConnectDeviceStatusChecker(TEST_ORG_ID, TEST_CLIENT_ID, environment, mockCallback)
 
         // test
         quickConnectDeviceStatusChecker.run()
@@ -246,7 +247,7 @@ class QuickConnectDeviceStatusCheckerTest {
         ).toString().toByteArray()
 
         val expectedNetworkRequest = NetworkRequest(
-            "${QuickConnect.BASE_DEVICE_API_URL}/${QuickConnect.DEVICE_API_PATH_STATUS}",
+            "${getBaseUrl(environment)}/${QuickConnect.DEVICE_API_PATH_STATUS}",
             HttpMethod.POST,
             expectedBody,
             mapOf(
@@ -280,5 +281,10 @@ class QuickConnectDeviceStatusCheckerTest {
     @After
     fun teardown() {
         mockedStaticServiceProvider.close()
+    }
+
+    private fun getBaseUrl(environment: String): String {
+        val prefixedEnv = if (environment.isNotEmpty()) "-$environment" else ""
+        return String.format(QuickConnect.BASE_DEVICE_API_URL_FORMAT, prefixedEnv)
     }
 }

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/internal/QuickConnectManagerTest.kt
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/internal/QuickConnectManagerTest.kt
@@ -91,6 +91,7 @@ class QuickConnectManagerTest {
         quickConnectManager = QuickConnectManager(
             mockAssuranceStateManager,
             mockExecutorService,
+            "",
             mockQuickConnectCallback
         )
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Make QuickConnect Authorization environment aware for test/development purposes.
- Align with dev-v3.x
- Adds the ability for fetching `environment` shared preferences
- Plumb environment into quick connect tasks

<!--- Describe your changes in detail -->

## Related Issue
Internal - MOB-20770 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Make QuickConnect Authorization environment aware for test/development purposes.
- Adds the ability for fetching `environment` shared preferences
- Plumb environment into quick connect tasks
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Manual tests
- Unit tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.