### PR TITLE
Always show floating button during Assurance session reconnection

### DIFF
--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/AssuranceSessionPresentationManager.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/AssuranceSessionPresentationManager.kt
@@ -65,12 +65,17 @@ internal class AssuranceSessionPresentationManager {
     /** Shows the UI elements that are required when a session connection has been disconnected.  */
     @JvmName("onSessionDisconnected")
     internal fun onSessionDisconnected(closeCode: Int) {
+        // Remove the button from the UI on any disconnection. This is OK since
+        // 1. The button will be  re-added when the session is connected via (onSessionConnected) or
+        //    re-connected (onSessionReconnecting) again after an error.
+        // 2. The button is not shown anyway when the Assurance Authorization UI is active.
+        button.remove()
+
         val error = SocketCloseCode.toAssuranceConnectionError(closeCode)
         if (error == null) {
             AssuranceComponentRegistry.appState.onSessionPhaseChange(
                 AssuranceAppState.SessionPhase.Disconnected()
             )
-            button.remove()
             logLocalUI(
                 UILogColorVisibility.LOW,
                 "Assurance disconnected."
@@ -96,7 +101,11 @@ internal class AssuranceSessionPresentationManager {
      */
     @JvmName("onSessionReconnecting")
     internal fun onSessionReconnecting() {
-        button.updateGraphic(false)
+        button.apply {
+            show()
+            updateGraphic(connected = false)
+        }
+
         logLocalUI(
             UILogColorVisibility.HIGH,
             "Assurance disconnected, attempting to reconnect ..."

--- a/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/internal/AssuranceSessionPresentationManagerTest.kt
+++ b/code/assurance/src/test/java/com/adobe/marketing/mobile/assurance/internal/AssuranceSessionPresentationManagerTest.kt
@@ -124,6 +124,9 @@ class AssuranceSessionPresentationManagerTest {
 
         // Verify
 
+        // Floating button should be removed on disconnection
+        verify(mockAssuranceFloatingButton).remove()
+
         // Session phase should remain in Authorizing phase because the UI is active
         assertEquals(
             AssuranceAppState.SessionPhase.Authorizing(credentials),
@@ -131,7 +134,6 @@ class AssuranceSessionPresentationManagerTest {
         )
 
         // no changes in ui elements
-        verify(mockAssuranceFloatingButton, never()).remove()
         verify(mockActivity, never()).startActivity(any())
     }
 
@@ -210,6 +212,7 @@ class AssuranceSessionPresentationManagerTest {
         assuranceSessionPresentationManager.onSessionReconnecting()
 
         // Verify
+        verify(mockAssuranceFloatingButton).show()
         verify(mockAssuranceFloatingButton).updateGraphic(false)
         val currentPhase = AssuranceComponentRegistry.appState.sessionPhase.value
         assertTrue { currentPhase is AssuranceAppState.SessionPhase.Disconnected }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently, the floating button is not shown when the SDK is attempting to reconnect to a previous session (immediately after app launch) until the re-connection is successful.  This behavior in 3.x may cause a confusion when there is a prolonged time taken during reconnection - example: 
1. SDK connects to a session -> _Floating button is shown_
2. App is closed 
3. Device gets disconnected from network
4. App is launched again when disconnected from network ->  _Floating button is not shown_ (despite active)
5. a significant amount of time passes
6. Device gets is connected to network
7. SDK connects to a session -> _Floating button is shown_

The bug occurs because reconnection flow attempts to update the graphic for a button that has never been active/shown.
This is a regression from 2.x where the floating button shows up (with a disconnected icon) indicating that reconnection is in progress. 
This PR fixes the behavior to always show the floating button during reconnecting state before updating to show disconnected graphic and always remove the floating button on any disconnection.

<!--- Describe your changes in detail -->

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Unit tests
- Manual test with test app
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.