### PR TITLE
Prepare for Assurance SDK localization

### DIFF
--- a/code/assurance/src/androidTest/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/error/PinErrorViewTest.kt
+++ b/code/assurance/src/androidTest/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/error/PinErrorViewTest.kt
@@ -11,6 +11,7 @@
 
 package com.adobe.marketing.mobile.assurance.internal.ui.pin.error
 
+import android.app.Application
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertTextEquals
@@ -20,9 +21,12 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.test.platform.app.InstrumentationRegistry
+import com.adobe.marketing.mobile.MobileCore
 import com.adobe.marketing.mobile.assurance.internal.AssuranceConstants
 import com.adobe.marketing.mobile.assurance.internal.ui.AssuranceUiTestTags
 import com.adobe.marketing.mobile.assurance.internal.ui.pin.PinScreenAction
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
@@ -32,6 +36,11 @@ class PinErrorViewTest {
     val composeTestRule = createComposeRule()
 
     private val actions = mutableListOf<PinScreenAction>()
+
+    @Before
+    fun setUp() {
+        MobileCore.setApplication(InstrumentationRegistry.getInstrumentation().context.applicationContext as Application)
+    }
 
     @Test
     fun testPinErrorViewWithRetryableError() {

--- a/code/assurance/src/androidTest/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectViewTests.kt
+++ b/code/assurance/src/androidTest/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectViewTests.kt
@@ -11,6 +11,7 @@
 
 package com.adobe.marketing.mobile.assurance.internal.ui.quickconnect
 
+import android.app.Application
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertAny
 import androidx.compose.ui.test.assertHasClickAction
@@ -22,15 +23,23 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.platform.app.InstrumentationRegistry
+import com.adobe.marketing.mobile.MobileCore
 import com.adobe.marketing.mobile.assurance.internal.AssuranceConstants
 import com.adobe.marketing.mobile.assurance.internal.ui.AssuranceUiTestTags
 import com.adobe.marketing.mobile.assurance.internal.ui.common.ConnectionState
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
 class QuickConnectViewTests {
     @get: Rule
     val composeTestRule = createComposeRule()
+
+    @Before
+    fun setUp() {
+        MobileCore.setApplication(InstrumentationRegistry.getInstrumentation().context.applicationContext as Application)
+    }
 
     @Test
     fun testQuickConnectViewWhenIdle() {

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/AssuranceConstants.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/AssuranceConstants.kt
@@ -11,6 +11,8 @@
 
 package com.adobe.marketing.mobile.assurance.internal
 
+import com.adobe.marketing.mobile.assurance.R
+import com.adobe.marketing.mobile.services.ServiceProvider
 import java.util.concurrent.TimeUnit
 
 internal object AssuranceConstants {
@@ -230,76 +232,93 @@ internal object AssuranceConstants {
     }
 
     internal enum class AssuranceConnectionError(
-        val error: String,
-        val description: String,
+        private val errorResId: Int,
+        private val descriptionResId: Int,
         @JvmField val isRetryable: Boolean
     ) {
         GENERIC_ERROR(
-            "Connection Error",
-            "The connection may be failing due to a network issue or an incorrect Pin. " +
-                "Please verify internet connectivity or the Pin and try again.",
+            R.string.error_title_incorrect_pin_or_network,
+            R.string.error_desc_incorrect_pin_or_network,
             true
         ),
         NO_ORG_ID(
-            "Invalid Configuration",
-            "The Experience Cloud organization identifier is unavailable from the SDK. Ensure" +
-                " SDK configuration is setup correctly. See documentation for more detail.",
+            R.string.error_title_invalid_org_id,
+            R.string.error_desc_invalid_org_id,
             false
         ),
         ORG_ID_MISMATCH(
-            "Unauthorized Access",
-            "The Experience Cloud organization identifier does not match with that of the" +
-                " Assurance session. Ensure the right Experience Cloud organization is being" +
-                " used. See documentation for more detail.",
+            R.string.error_title_unauthorized_access,
+            R.string.error_desc_unauthorized_access,
             false
         ),
         CONNECTION_LIMIT(
-            "Connection Limit Reached",
-            "You have reached the maximum number of connected devices allowed for a session. " +
-                "Please disconnect another device and try again.",
+            R.string.error_title_connection_limit,
+            R.string.error_desc_connection_limit,
             false
         ),
         EVENT_LIMIT(
-            "Event Limit Reached",
-            "You have reached the maximum number of events that can be sent per minute.",
+            R.string.error_title_event_limit,
+            R.string.error_desc_event_limit,
             false
         ),
         CLIENT_ERROR(
-            "Client Disconnected",
-            "This client has been disconnected due to an unexpected error. Error Code 4400.",
+            R.string.error_title_unexpected_error,
+            R.string.error_desc_unexpected_error,
             false
         ),
         SESSION_DELETED(
-            "Session Deleted",
-            "The session client connected to has been deleted. Error Code 4903.",
+            R.string.error_title_session_deleted,
+            R.string.error_desc_session_deleted,
             false
         ),
         CREATE_DEVICE_REQUEST_MALFORMED(
-            "Malformed Request",
-            "The network request for device creation was malformed.",
+            R.string.error_title_invalid_registration_request,
+            R.string.error_desc_invalid_registration_request,
             false
         ),
         STATUS_CHECK_REQUEST_MALFORMED(
-            "Malformed Request",
-            "The network request for status check  was malformed.",
+            R.string.error_title_invalid_registration_request,
+            R.string.error_desc_invalid_registration_request,
             false
         ),
         RETRY_LIMIT_REACHED(
-            "Retry Limit Reached",
-            "The maximum allowed retries for fetching the session details were reached.",
+            R.string.error_title_retry_limit_reached,
+            R.string.error_desc_retry_limit_reached,
             true
         ),
         CREATE_DEVICE_REQUEST_FAILED(
-            "Request Failed",
-            "Failed to register device.",
+            R.string.error_title_registration_error,
+            R.string.error_desc_registration_error,
             true
         ),
         DEVICE_STATUS_REQUEST_FAILED(
-            "Request Failed",
-            "Failed to get device status",
+            R.string.error_title_registration_error,
+            R.string.error_desc_registration_error,
             true
         ),
-        UNEXPECTED_ERROR("Unexpected Error", "An unexpected error occurred", true)
+        UNEXPECTED_ERROR(
+            R.string.error_title_invalid_registration_response,
+            R.string.error_desc_invalid_registration_response,
+            true
+        );
+
+        val error: String
+            get() {
+                val context = ServiceProvider.getInstance().appContextService.applicationContext
+                // This code path should never be crossed if the app context is null because the SDK
+                // operations require a valid context. Default to empty string if context is null
+                // because we don't want to crash the app.
+                return context?.getString(errorResId) ?: ""
+            }
+
+        val description: String
+            get() {
+                val context = ServiceProvider.getInstance().appContextService.applicationContext
+                // This code path should never be crossed if the app context is null because the SDK
+                // operations require a valid context. Default to empty string if context is null
+                // because we don't want to crash the app.
+                return context?.getString(descriptionResId) ?: ""
+            }
     }
 
     internal enum class UILogColorVisibility(val value: Int) {

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/error/AssuranceErrorScreen.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/error/AssuranceErrorScreen.kt
@@ -97,7 +97,7 @@ internal fun AssuranceErrorScreen(assuranceConnectionError: AssuranceConstants.A
             modifier = Modifier.align(Alignment.BottomCenter)
         ) {
             Text(
-                text = stringResource(id = R.string.pin_connect_button_dismiss),
+                text = stringResource(id = R.string.error_screen_button_dismiss),
                 fontFamily = FontFamily.SansSerif,
                 style = TextStyle(color = Color.White, fontSize = 24.sp)
             )

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/ActionButtonRow.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/ActionButtonRow.kt
@@ -58,7 +58,7 @@ internal fun ActionButtonRow(
             }
         ) {
             Text(
-                text = stringResource(id = R.string.pin_connect_button_cancel),
+                text = stringResource(id = R.string.pin_screen_button_cancel),
                 fontFamily = FontFamily.SansSerif,
                 style = TextStyle(color = Color.White, fontSize = 24.sp)
             )
@@ -71,7 +71,7 @@ internal fun ActionButtonRow(
                 onClick = { onAction(PinScreenAction.Connect(pin)) }
             ) {
                 Text(
-                    text = stringResource(id = R.string.pin_connect_button_connect),
+                    text = stringResource(id = R.string.pin_screen_button_connect),
                     fontFamily = FontFamily.SansSerif,
                     style = TextStyle(color = Color.White, fontSize = 24.sp)
                 )

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/DialPadView.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/DialPadView.kt
@@ -56,7 +56,7 @@ internal fun DialPadView(
             verticalArrangement = Arrangement.spacedBy(AssuranceTheme.dimensions.spacing.medium)
         ) {
             AssuranceHeader()
-            AssuranceSubHeader(text = stringResource(id = R.string.pin_connect_enter_pin_text))
+            AssuranceSubHeader(text = stringResource(id = R.string.pin_screen_header))
             InputFeedbackRow(input = pinScreenState.value.pin)
             NumberRow(listOf("1", "2", "3"), onClick = { action -> onAction(action) })
             NumberRow(listOf("4", "5", "6"), onClick = { action -> onAction(action) })

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/error/ActionButtonRow.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/error/ActionButtonRow.kt
@@ -54,7 +54,7 @@ internal fun ActionButtonRow(
             }
         ) {
             Text(
-                text = stringResource(id = R.string.pin_connect_button_cancel),
+                text = stringResource(id = R.string.pin_screen_button_cancel),
                 fontFamily = FontFamily.SansSerif,
                 style = TextStyle(color = Color.White, fontSize = 24.sp)
             )
@@ -66,7 +66,7 @@ internal fun ActionButtonRow(
                 onClick = { onAction(PinScreenAction.Retry) }
             ) {
                 Text(
-                    text = stringResource(id = R.string.pin_connect_button_retry),
+                    text = stringResource(id = R.string.pin_screen_button_retry),
                     fontFamily = FontFamily.SansSerif,
                     style = TextStyle(color = Color.White, fontSize = 24.sp)
                 )

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/ActionButtonRow.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/ActionButtonRow.kt
@@ -75,7 +75,7 @@ internal fun ActionButtonRow(
             )
         ) {
             Text(
-                text = stringResource(id = R.string.quick_connect_button_cancel),
+                text = stringResource(id = R.string.quick_connect_screen_button_cancel),
                 fontFamily = AssuranceTheme.typography.font.family,
                 style = TextStyle(color = Color.White, fontSize = AssuranceTheme.typography.font.size.medium.sp)
             )

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/ProgressButton.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/ProgressButton.kt
@@ -134,7 +134,7 @@ internal sealed class ButtonState(
         foregroundColor: Color = Color.White,
         clickable: Boolean = true
     ) : ButtonState(
-        R.string.quick_connect_button_connect,
+        R.string.quick_connect_screen_button_connect,
         backgroundColor,
         foregroundColor,
         clickable
@@ -148,7 +148,7 @@ internal sealed class ButtonState(
         foregroundColor: Color = Color.White,
         clickable: Boolean = false
     ) : ButtonState(
-        R.string.quick_connect_button_waiting,
+        R.string.quick_connect_screen_button_waiting,
         backgroundColor,
         foregroundColor,
         clickable
@@ -162,7 +162,7 @@ internal sealed class ButtonState(
         foregroundColor: Color = Color.White,
         clickable: Boolean = true
     ) : ButtonState(
-        R.string.quick_connect_button_retry,
+        R.string.quick_connect_screen_button_retry,
         backgroundColor,
         foregroundColor,
         clickable

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectView.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectView.kt
@@ -59,7 +59,7 @@ internal fun QuickConnectView(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             AssuranceHeader()
-            AssuranceSubHeader(text = stringResource(id = R.string.quick_connect_description))
+            AssuranceSubHeader(text = stringResource(id = R.string.quick_connect_screen_header))
 
             // Quick Connect  flow image
             Image(

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/status/AssuranceStatusScreen.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/status/AssuranceStatusScreen.kt
@@ -107,7 +107,7 @@ internal fun AssuranceStatusScreen() {
         ) {
             TextButton(onClick = { AssuranceComponentRegistry.appState.clearLogs() }) {
                 Text(
-                    text = stringResource(id = R.string.status_button_clear_log),
+                    text = stringResource(id = R.string.status_screen_button_clear_log),
                     fontFamily = FontFamily.SansSerif,
                     style = TextStyle(color = Color.White, fontSize = 14.sp)
                 )
@@ -126,7 +126,7 @@ internal fun AssuranceStatusScreen() {
                 )
             ) {
                 Text(
-                    text = stringResource(id = R.string.status_button_disconnect),
+                    text = stringResource(id = R.string.status_screen_button_disconnect),
                     fontFamily = FontFamily.SansSerif,
                     style = TextStyle(color = Color.Red, fontSize = 14.sp)
                 )

--- a/code/assurance/src/main/res/values/strings.xml
+++ b/code/assurance/src/main/res/values/strings.xml
@@ -12,17 +12,62 @@
 <resources>
     <string name="app_name">Assurance</string>
     <string name="assurance_title">Assurance</string>
-    <string name="quick_connect_description">Confirm connection by visiting your session\'s connection detail screen</string>
-    <string name="quick_connect_button_connect">Connect</string>
-    <string name="quick_connect_button_cancel">Cancel</string>
-    <string name="quick_connect_button_waiting">Waiting..</string>
-    <string name="quick_connect_button_retry">Retry</string>
-    <string name="pin_connect_button_dismiss">Dismiss</string>
-    <string name="pin_connect_button_cancel">Cancel</string>
-    <string name="pin_connect_button_connect">Connect</string>
-    <string name="pin_connect_button_retry">Retry</string>
-    <string name="pin_connect_enter_pin_text">Enter the 4 digit PIN to continue</string>
-    <string name="status_button_disconnect">Disconnect</string>
-    <string name="status_button_clear_log">Clear Log</string>
+
+    <string name="pin_screen_header">Enter the 4 digit PIN to continue</string>
+    <string name="pin_screen_button_connect">Connect</string>
+    <string name="pin_screen_button_cancel">Cancel</string>
+    <string name="pin_screen_button_retry">Retry</string>
+    <string name="pin_screen_connecting">Connecting...</string>
+
+    <string name="status_screen_header">Logs</string>
+    <string name="status_screen_button_disconnect">Disconnect</string>
+    <string name="status_screen_button_clear_log">Clear Log</string>
+    <string name="status_screen_button_cancel">Cancel</string>
+
+    <string name="error_screen_button_dismiss">Dismiss</string>
+    <string name="quick_connect_screen_header">Confirm connection by visiting your session\'s connection detail screen</string>
+    <string name="quick_connect_screen_button_connect">Connect</string>
+    <string name="quick_connect_screen_button_retry">Retry</string>
+    <string name="quick_connect_screen_button_cancel">Cancel</string>
+    <string name="quick_connect_screen_button_waiting">Waiting..</string>
+
+    <string name="error_title_incorrect_pin_or_network">Connection Error</string>
+    <string name="error_desc_incorrect_pin_or_network">The connection may be failing due to a network issue or an incorrect PIN. Please verify internet connectivity or the PIN and try again.</string>
+
+    <string name="error_title_invalid_pin">Authorization Error</string>
+    <string name="error_desc_invalid_pin">Unable to authorize Assurance connection. Please verify the PIN and try again.</string>
+
+    <string name="error_title_invalid_org_id">Invalid Mobile SDK Configuration</string>
+    <string name="error_desc_invalid_org_id">The Experience Cloud organization identifier is unavailable. Ensure SDK configuration is setup correctly. See documentation for more detail.</string>
+
+    <string name="error_title_unauthorized_access">Unauthorized Access</string>
+    <string name="error_desc_unauthorized_access">The Experience Cloud organization identifier does not match with that of the Assurance session. Ensure the right Experience Cloud organization is being used. See documentation for more detail.</string>
+
+    <string name="error_title_connection_limit">Connection Limit Reached</string>
+    <string name="error_desc_connection_limit">You have reached the maximum number of connected device allowed to a session.</string>
+
+    <string name="error_title_event_limit">Event Limit Reached</string>
+    <string name="error_desc_event_limit">You have reached the maximum number of events that can be sent per minute.</string>
+
+    <string name="error_title_session_deleted">Session Deleted</string>
+    <string name="error_desc_session_deleted">You attempted to connect to a deleted session.</string>
+
+    <string name="error_title_unexpected_error">Client Disconnected</string>
+    <string name="error_desc_unexpected_error">This client has been disconnected due to an unexpected error.</string>
+
+    <string name="error_title_invalid_url">Invalid URL</string>
+    <string name="error_desc_invalid_url">Attempted a network request with an invalid url.</string>
+
+    <string name="error_title_invalid_registration_request">Connection Error</string>
+    <string name="error_desc_invalid_registration_request">The connection may be failing due to an invalid network request.</string>
+
+    <string name="error_title_retry_limit_reached">Retry Limit Reached</string>
+    <string name="error_desc_retry_limit_reached">The maximum allowed retries for fetching the session details were reached.</string>
+
+    <string name="error_title_invalid_registration_response">Invalid Response data</string>
+    <string name="error_desc_invalid_registration_response">Connection failed due to an invalid response.</string>
+
+    <string name="error_title_registration_error">Connection Error</string>
+    <string name="error_desc_registration_error">Error occurred during device registration or status check.</string>
 
 </resources>


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
Assurance SDK UI strings are being localized. Before ingesting the localized strings, prepare the SDK for localization
- Move all UI strings to be used from resources
- Use the standardized versions of the Strings

<!--- Describe your changes in detail -->

## Related Issue
(Internal) MOB-20765

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Assurance SDK UI strings are being localized. Before ingesting the localized strings, prepare the SDK for localization
- Move all UI strings to be used from resources
- Use the standardized versions of the Strings

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.