### PR TITLE
Remove orientation restrictions for Assurance screens

### DIFF
--- a/code/assurance-testapp/build.gradle.kts
+++ b/code/assurance-testapp/build.gradle.kts
@@ -80,15 +80,16 @@ android {
         implementation("androidx.navigation:navigation-compose:2.4.0")
 
         // AEP SDK dependencies
+        implementation(platform("com.adobe.marketing.mobile:sdk-bom:3.9.2"))
+        implementation("com.adobe.marketing.mobile:core")
+        // Use the assurance module from the local project
+        // Use the assurance module from the local project
         implementation(project(":assurance"))
-        implementation("com.adobe.marketing.mobile:core:3.0.0")
-        implementation("com.adobe.marketing.mobile:signal:3.0.0")
-        implementation("com.adobe.marketing.mobile:lifecycle:3.0.0")
-        // Messaging, Edge, and EdgeIdentity will be available after Core, Assurance release.
-        // Use Snapshot version for initial Assurance release.
-        implementation("com.adobe.marketing.mobile:messaging:3.0.0")
-        implementation("com.adobe.marketing.mobile:edge:3.0.0")
-        implementation("com.adobe.marketing.mobile:edgeidentity:3.0.0")
+        implementation("com.adobe.marketing.mobile:signal")
+        implementation("com.adobe.marketing.mobile:lifecycle")
+        implementation("com.adobe.marketing.mobile:messaging")
+        implementation("com.adobe.marketing.mobile:edge")
+        implementation("com.adobe.marketing.mobile:edgeidentity")
 
         testImplementation("junit:junit:4.13.2")
 

--- a/code/assurance/build.gradle.kts
+++ b/code/assurance/build.gradle.kts
@@ -41,4 +41,6 @@ dependencies {
     testImplementation("net.sf.kxml:kxml2:2.3.0@jar")
     testImplementation("org.json:json:20171018")
     testImplementation("org.robolectric:robolectric:4.7")
+
+    androidTestImplementation("androidx.test.uiautomator:uiautomator:2.3.0")
 }

--- a/code/assurance/src/androidTest/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/PinScreenVerificationUtils.kt
+++ b/code/assurance/src/androidTest/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/PinScreenVerificationUtils.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollTo
 import com.adobe.marketing.mobile.assurance.internal.ui.AssuranceUiTestTags
 
 internal object PinScreenVerificationUtils {
@@ -31,7 +32,7 @@ internal object PinScreenVerificationUtils {
     private const val ASSURANCE_HEADER_TEXT = "Assurance"
     private const val ASSURANCE_SUB_HEADER_TEXT = "Enter the 4 digit PIN to continue"
 
-    internal fun verifyDialPadIdleSetup(composeTestRule: ComposeContentTestRule) {
+    internal fun verifyDialPadIdleSetup(composeTestRule: ComposeContentTestRule, scrollIfNecessary: Boolean = false) {
         // Verify the dial pad view exists and is displayed
         composeTestRule.onNodeWithTag(
             AssuranceUiTestTags.PinScreen.DIAL_PAD_VIEW,
@@ -61,21 +62,23 @@ internal object PinScreenVerificationUtils {
         )
             .onChildren()
             .filter(hasTestTag(AssuranceUiTestTags.PinScreen.NUMBER_ROW))
-        verifyDialPad(numberRows)
+        verifyDialPad(numberRows, scrollIfNecessary)
 
         // Verify the symbol row exists and is displayed
         val symbolRow = composeTestRule.onNodeWithTag(
             AssuranceUiTestTags.PinScreen.SYMBOL_ROW,
             useUnmergedTree = true
         )
-        verifySymbolRow(symbolRow)
+        verifySymbolRow(symbolRow, scrollIfNecessary)
 
         // Verify the action button row exists and is displayed
         val actionButtonRow = composeTestRule.onNodeWithTag(
             AssuranceUiTestTags.PinScreen.DIAL_PAD_ACTION_BUTTON_ROW,
             useUnmergedTree = true
         )
-        actionButtonRow.assertExists().assertIsDisplayed()
+        actionButtonRow.assertExists()
+            .also { if (scrollIfNecessary) it.performScrollTo() }
+            .assertIsDisplayed()
 
         // Verify the action button row buttons
         actionButtonRow.onChildren()
@@ -93,14 +96,16 @@ internal object PinScreenVerificationUtils {
             .assertCountEquals(0)
     }
 
-    private fun verifyDialPad(numberRows: SemanticsNodeInteractionCollection) {
+    private fun verifyDialPad(numberRows: SemanticsNodeInteractionCollection, scrollIfNecessary: Boolean) {
         // Verify the number row exists and is displayed
         numberRows.assertCountEquals(3)
 
         // Verify the number row buttons
         // - Each number row should have 3 buttons
         // - Each button should have a text child
-        numberRows[0].onChildren().assertCountEquals(3)
+        numberRows[0]
+            .apply { if (scrollIfNecessary) performScrollTo() }
+            .onChildren().assertCountEquals(3)
             .filter(hasTestTag(AssuranceUiTestTags.PinScreen.DIAL_PAD_BUTTON))
             .apply {
                 get(0).onChildren()
@@ -117,10 +122,14 @@ internal object PinScreenVerificationUtils {
                     .childrenDisplayed(1)
             }
 
-        numberRows[1].onChildren().assertCountEquals(3)
+        numberRows[1]
+            .apply { if (scrollIfNecessary) performScrollTo() }
+            .onChildren()
+            .assertCountEquals(3)
             .filter(hasTestTag(AssuranceUiTestTags.PinScreen.DIAL_PAD_BUTTON))
             .apply {
-                get(0).onChildren()
+                get(0)
+                    .onChildren()
                     .filter(hasTestTag(AssuranceUiTestTags.PinScreen.DIAL_PAD_NUMERIC_BUTTON_TEXT))
                     .assertAny(hasText("4"))
                     .childrenDisplayed(1)
@@ -134,7 +143,10 @@ internal object PinScreenVerificationUtils {
                     .childrenDisplayed(1)
             }
 
-        numberRows[2].onChildren().assertCountEquals(3)
+        numberRows[2]
+            .apply { if (scrollIfNecessary) performScrollTo() }
+            .onChildren()
+            .assertCountEquals(3)
             .filter(hasTestTag(AssuranceUiTestTags.PinScreen.DIAL_PAD_BUTTON))
             .apply {
                 get(0).onChildren()
@@ -164,16 +176,21 @@ internal object PinScreenVerificationUtils {
         }
     }
 
-    private fun verifySymbolRow(symbolRow: SemanticsNodeInteraction) {
+    private fun verifySymbolRow(symbolRow: SemanticsNodeInteraction, scrollIfNecessary: Boolean) {
 
-        symbolRow.assertExists().assertIsDisplayed()
-        symbolRow.onChildren().apply {
-            get(0).onChildren()[0].assertTextEquals("")
-            get(1).onChildren().childrenDisplayed(1)[0].assertTextEquals("0")
-            get(2).onChildren().childrenDisplayed(1).assertAny(
-                hasContentDescription("Delete")
-            )
-        }
+        symbolRow.assertExists()
+            .apply { if (scrollIfNecessary) performScrollTo() }
+            .assertIsDisplayed()
+        symbolRow
+            .apply { if (scrollIfNecessary) performScrollTo() }
+            .onChildren()
+            .apply {
+                get(0).onChildren()[0].assertTextEquals("")
+                get(1).onChildren().childrenDisplayed(1)[0].assertTextEquals("0")
+                get(2).onChildren().childrenDisplayed(1).assertAny(
+                    hasContentDescription("Delete")
+                )
+            }
     }
 
     internal fun SemanticsNodeInteractionCollection.childrenDisplayed(count: Int): SemanticsNodeInteractionCollection {

--- a/code/assurance/src/androidTest/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/DialPadViewTests.kt
+++ b/code/assurance/src/androidTest/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/DialPadViewTests.kt
@@ -22,6 +22,9 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import com.adobe.marketing.mobile.assurance.internal.ui.AssuranceUiTestTags
 import com.adobe.marketing.mobile.assurance.internal.ui.pin.PinScreenAction
 import com.adobe.marketing.mobile.assurance.internal.ui.pin.PinScreenState
@@ -50,6 +53,27 @@ class DialPadViewTests {
 
         // Verify
         verifyDialPadIdleSetup(composeTestRule)
+    }
+
+    @Test
+    fun testDialPadViewIdleSetupInLandscapeMode() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val uiDevice = UiDevice.getInstance(instrumentation)
+        uiDevice.setOrientationLandscape()
+
+        val pinScreenState = mutableStateOf(PinScreenState())
+        composeTestRule.setContent {
+            DialPadView(
+                pinScreenState = pinScreenState,
+                onAction = { action -> pinScreenActions += action }
+            )
+        }
+
+        // Verify
+        verifyDialPadIdleSetup(composeTestRule, true)
+
+        // Reset orientation
+        uiDevice.setOrientationNatural()
     }
 
     @Test
@@ -86,6 +110,48 @@ class DialPadViewTests {
         assertEquals(PinScreenAction.Number("3"), pinScreenActions[1])
         assertEquals(PinScreenAction.Number("5"), pinScreenActions[2])
         assertEquals(PinScreenAction.Number("8"), pinScreenActions[3])
+    }
+
+    @Test
+    fun testDialPadViewWhenPinIsEnteredInLandscapeMode() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val uiDevice = UiDevice.getInstance(instrumentation)
+        uiDevice.setOrientationLandscape()
+
+        val pinScreenState = mutableStateOf(PinScreenState())
+        composeTestRule.setContent {
+            DialPadView(
+                pinScreenState = pinScreenState,
+                onAction = { action -> pinScreenActions += action }
+            )
+        }
+
+        // Verify idle setup
+        verifyDialPadIdleSetup(composeTestRule, true)
+
+        assertTrue(pinScreenActions.isEmpty())
+
+        val numberRows = composeTestRule.onNodeWithTag(
+            AssuranceUiTestTags.PinScreen.DIAL_PAD_VIEW,
+            useUnmergedTree = true
+        ).onChildren()
+            .filter(hasTestTag(AssuranceUiTestTags.PinScreen.NUMBER_ROW))
+
+        // Enter a pin 1358
+        numberRows[0].performScrollTo().onChildren()[0].performClick() // 1
+        numberRows[0].performScrollTo().onChildren()[2].performClick() // 3
+        numberRows[1].performScrollTo().onChildren()[1].performClick() // 5
+        numberRows[2].performScrollTo().onChildren()[1].performClick() // 8
+        composeTestRule.waitForIdle()
+
+        // Verify that the pin screen actions are recorded
+        assertEquals(PinScreenAction.Number("1"), pinScreenActions[0])
+        assertEquals(PinScreenAction.Number("3"), pinScreenActions[1])
+        assertEquals(PinScreenAction.Number("5"), pinScreenActions[2])
+        assertEquals(PinScreenAction.Number("8"), pinScreenActions[3])
+
+        // Reset orientation
+        uiDevice.setOrientationNatural()
     }
 
     @Test
@@ -129,6 +195,56 @@ class DialPadViewTests {
         assertEquals(PinScreenAction.Number("3"), pinScreenActions[2])
         assertEquals(PinScreenAction.Number("1"), pinScreenActions[3])
         assertEquals(PinScreenAction.Delete, pinScreenActions[4])
+    }
+
+    @Test
+    fun testDialPadViewWhenPinIsEnteredAndClearedInLandscapeMode() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val uiDevice = UiDevice.getInstance(instrumentation)
+        uiDevice.setOrientationLandscape()
+
+        val pinScreenState = mutableStateOf(PinScreenState())
+        composeTestRule.setContent {
+            DialPadView(
+                pinScreenState = pinScreenState,
+                onAction = { action -> pinScreenActions += action }
+            )
+        }
+
+        // Verify idle setup
+        verifyDialPadIdleSetup(composeTestRule, true)
+        assertTrue(pinScreenActions.isEmpty())
+
+        val numberRows = composeTestRule.onNodeWithTag(
+            AssuranceUiTestTags.PinScreen.DIAL_PAD_VIEW,
+            useUnmergedTree = true
+        )
+            .onChildren()
+            .filter(hasTestTag(AssuranceUiTestTags.PinScreen.NUMBER_ROW))
+
+        // Enter a pin 1231
+        numberRows[0].performScrollTo().onChildren()[0].performClick() // 1
+        numberRows[0].performScrollTo().onChildren()[1].performClick() // 2
+        numberRows[0].performScrollTo().onChildren()[2].performClick() // 3
+        numberRows[0].performScrollTo().onChildren()[0].performClick() // 1
+
+        val symbolRow = composeTestRule.onNodeWithTag(
+            AssuranceUiTestTags.PinScreen.SYMBOL_ROW,
+            useUnmergedTree = true
+        )
+
+        // Clear the pin with the delete button
+        symbolRow.performScrollTo().onChildren()[2].performClick() // delete
+
+        // Verify that the pin screen actions are recorded
+        assertEquals(PinScreenAction.Number("1"), pinScreenActions[0])
+        assertEquals(PinScreenAction.Number("2"), pinScreenActions[1])
+        assertEquals(PinScreenAction.Number("3"), pinScreenActions[2])
+        assertEquals(PinScreenAction.Number("1"), pinScreenActions[3])
+        assertEquals(PinScreenAction.Delete, pinScreenActions[4])
+
+        // Reset orientation
+        uiDevice.setOrientationNatural()
     }
 
     @Test
@@ -200,5 +316,49 @@ class DialPadViewTests {
                 it[0].onChildren()
                     .assertAny(hasText("Connect"))
             }
+    }
+
+    @Test
+    fun testDialPadViewWithFullPinEnteredInLandscapeMode() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val uiDevice = UiDevice.getInstance(instrumentation)
+        uiDevice.setOrientationLandscape()
+
+        // Simulate a pin screen with a pin fully entered
+        val pinScreenState = mutableStateOf(PinScreenState(pin = "1234"))
+        composeTestRule.setContent {
+            DialPadView(
+                pinScreenState = pinScreenState,
+                onAction = { action -> pinScreenActions += action }
+            )
+        }
+
+        // Verify the action button row exists and is displayed
+        val actionButtonRow = composeTestRule.onNodeWithTag(
+            AssuranceUiTestTags.PinScreen.DIAL_PAD_ACTION_BUTTON_ROW,
+            useUnmergedTree = true
+        )
+        actionButtonRow.assertExists().performScrollTo().assertIsDisplayed()
+
+        // Verify the action button row buttons
+        actionButtonRow.onChildren()
+            .filter(hasTestTag(AssuranceUiTestTags.PinScreen.DIAL_PAD_CANCEL_BUTTON))
+            .childrenDisplayed(1)
+            .also {
+                it[0].onChildren()
+                    .assertAny(hasText("Cancel"))
+            }
+
+        // Verify the "Connect Button" is displayed
+        actionButtonRow.onChildren()
+            .filter(hasTestTag(AssuranceUiTestTags.PinScreen.DIAL_PAD_CONNECT_BUTTON))
+            .childrenDisplayed(1)
+            .also {
+                it[0].onChildren()
+                    .assertAny(hasText("Connect"))
+            }
+
+        // Reset orientation
+        uiDevice.setOrientationNatural()
     }
 }

--- a/code/assurance/src/androidTest/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectViewTests.kt
+++ b/code/assurance/src/androidTest/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectViewTests.kt
@@ -51,6 +51,8 @@ class QuickConnectViewTests {
             )
         }
 
+        composeTestRule.waitForIdle()
+
         // Verify
         composeTestRule.onNodeWithTag(AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_VIEW).assertExists()
 

--- a/code/assurance/src/androidTest/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectViewTests.kt
+++ b/code/assurance/src/androidTest/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectViewTests.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import com.adobe.marketing.mobile.MobileCore
 import com.adobe.marketing.mobile.assurance.internal.AssuranceConstants
 import com.adobe.marketing.mobile.assurance.internal.ui.AssuranceUiTestTags
@@ -54,14 +55,17 @@ class QuickConnectViewTests {
         composeTestRule.waitForIdle()
 
         // Verify
-        composeTestRule.onNodeWithTag(AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_VIEW).assertExists()
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_VIEW)
+            .assertExists().assertIsDisplayed()
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_SCROLLVIEW)
+            .assertExists().assertIsDisplayed()
 
         // Verify the header and sub-header exist and are displayed
         composeTestRule.onNodeWithTag(AssuranceUiTestTags.ASSURANCE_HEADER).assertIsDisplayed()
         composeTestRule.onNodeWithTag(AssuranceUiTestTags.ASSURANCE_SUB_HEADER).assertIsDisplayed()
 
         composeTestRule.onNodeWithTag(
-            AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_VIEW,
+            AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_SCROLLVIEW,
             useUnmergedTree = true
         )
             .onChildren()
@@ -85,6 +89,60 @@ class QuickConnectViewTests {
     }
 
     @Test
+    fun testQuickConnectViewWhenIdleInLandscapeMode() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val uiDevice = UiDevice.getInstance(instrumentation)
+        uiDevice.setOrientationLandscape()
+
+        val quickConnectState = mutableStateOf<ConnectionState>(ConnectionState.Disconnected(null))
+        composeTestRule.setContent {
+            QuickConnectView(
+                quickConnectState = quickConnectState,
+                onAction = { /* no-op */ }
+            )
+        }
+
+        composeTestRule.waitForIdle()
+
+        // Verify
+        composeTestRule
+            .onNodeWithTag(AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_VIEW)
+            .assertExists().assertIsDisplayed()
+        composeTestRule
+            .onNodeWithTag(AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_SCROLLVIEW)
+            .assertExists().assertIsDisplayed()
+
+        // Verify the header and sub-header exist and are displayed
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.ASSURANCE_HEADER).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.ASSURANCE_SUB_HEADER).assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag(
+            AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_SCROLLVIEW,
+            useUnmergedTree = true
+        )
+            .onChildren()
+            .assertAny(
+                hasTestTag(AssuranceUiTestTags.QuickConnectScreen.CANCEL_BUTTON)
+            )
+            .assertAny(
+                hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_BUTTON)
+            )
+
+        composeTestRule.onNodeWithTag(
+            AssuranceUiTestTags.QuickConnectScreen.PROGRESS_BUTTON,
+            useUnmergedTree = true
+        )
+            .onChildren()
+            .assertAny(
+                hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_BUTTON_TEXT)
+            ).assertAny(
+                !hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_INDICATOR)
+            )
+
+        uiDevice.setOrientationNatural()
+    }
+
+    @Test
     fun testQuickConnectViewWhenConnecting() {
         val quickConnectState = mutableStateOf<ConnectionState>(ConnectionState.Disconnected(null))
         composeTestRule.setContent {
@@ -95,14 +153,17 @@ class QuickConnectViewTests {
         }
 
         // Verify the initial state of being idle and disconnected
-        composeTestRule.onNodeWithTag(AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_VIEW).assertExists()
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_VIEW)
+            .assertExists().assertIsDisplayed()
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_SCROLLVIEW)
+            .assertExists().assertIsDisplayed()
 
         // Verify the header and sub-header exist and are displayed
         composeTestRule.onNodeWithTag(AssuranceUiTestTags.ASSURANCE_HEADER).assertIsDisplayed()
         composeTestRule.onNodeWithTag(AssuranceUiTestTags.ASSURANCE_SUB_HEADER).assertIsDisplayed()
 
         composeTestRule.onNodeWithTag(
-            AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_VIEW,
+            AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_SCROLLVIEW,
             useUnmergedTree = true
         )
             .onChildren()
@@ -139,10 +200,88 @@ class QuickConnectViewTests {
         )
             .onChildren()
             .assertAny(
-                hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_BUTTON_TEXT).and(hasText("Waiting.."))
+                hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_BUTTON_TEXT).and(
+                    hasText(
+                        "Waiting.."
+                    )
+                )
             ).assertAny(
                 hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_INDICATOR)
             )
+    }
+
+    @Test
+    fun testQuickConnectViewWhenConnectingInLandscapeMode() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val uiDevice = UiDevice.getInstance(instrumentation)
+        uiDevice.setOrientationLandscape()
+
+        val quickConnectState = mutableStateOf<ConnectionState>(ConnectionState.Disconnected(null))
+        composeTestRule.setContent {
+            QuickConnectView(
+                quickConnectState = quickConnectState,
+                onAction = { /* no-op */ }
+            )
+        }
+
+        // Verify the initial state of being idle and disconnected
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_VIEW)
+            .assertExists().assertIsDisplayed()
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_SCROLLVIEW)
+            .assertExists().assertIsDisplayed()
+
+        // Verify the header and sub-header exist and are displayed
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.ASSURANCE_HEADER).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.ASSURANCE_SUB_HEADER).assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag(
+            AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_SCROLLVIEW,
+            useUnmergedTree = true
+        )
+            .onChildren()
+            .assertAny(
+                hasTestTag(AssuranceUiTestTags.QuickConnectScreen.CANCEL_BUTTON)
+            )
+            .assertAny(
+                hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_BUTTON)
+            )
+
+        composeTestRule.onNodeWithTag(
+            AssuranceUiTestTags.QuickConnectScreen.PROGRESS_BUTTON,
+            useUnmergedTree = true
+        )
+            .onChildren()
+            .assertAny(
+                hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_BUTTON_TEXT)
+            ).assertAny(
+                !hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_INDICATOR)
+            )
+
+        // Update the state to connecting
+        quickConnectState.value = ConnectionState.Connecting
+        composeTestRule.waitForIdle()
+
+        // Verify that the progress button responds to Connecting state and shows the progress indicator
+        // Note that ideally this test should also check that the progress button is not clickable.
+        // However, the test framework does not checking for clickability of a Composable and
+        // on the assertion of whether or not a click action can be performed.
+        // Refer to the ProgressButtonTests.kt file for the click logic tests.
+        composeTestRule.onNodeWithTag(
+            AssuranceUiTestTags.QuickConnectScreen.PROGRESS_BUTTON,
+            useUnmergedTree = true
+        )
+            .onChildren()
+            .assertAny(
+                hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_BUTTON_TEXT).and(
+                    hasText(
+                        "Waiting.."
+                    )
+                )
+            ).assertAny(
+                hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_INDICATOR)
+            )
+
+        uiDevice.setOrientationNatural()
     }
 
     @Test
@@ -200,9 +339,84 @@ class QuickConnectViewTests {
         )
             .onChildren()
             .assertAny(
-                hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_BUTTON_TEXT).and(hasText("Retry"))
+                hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_BUTTON_TEXT).and(
+                    hasText(
+                        "Retry"
+                    )
+                )
             ).assertAny(
                 !hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_INDICATOR)
             )
+    }
+
+    @Test
+    fun testQuickConnectViewWhenDisconnectedWithErrorInLandscapeMode() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val uiDevice = UiDevice.getInstance(instrumentation)
+        uiDevice.setOrientationLandscape()
+
+        val quickConnectState = mutableStateOf<ConnectionState>(ConnectionState.Disconnected(null))
+        composeTestRule.setContent {
+            QuickConnectView(
+                quickConnectState = quickConnectState,
+                onAction = { /* no-op */ }
+            )
+        }
+
+        // Update the state to connecting
+        quickConnectState.value = ConnectionState.Connecting
+        composeTestRule.waitForIdle()
+
+        // Verify the header and sub-header exist and are displayed
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.ASSURANCE_HEADER).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.ASSURANCE_SUB_HEADER).assertIsDisplayed()
+
+        // Verify that the progress button responds to Connecting state and shows the progress indicator
+        composeTestRule.onNodeWithTag(
+            AssuranceUiTestTags.QuickConnectScreen.PROGRESS_BUTTON,
+            useUnmergedTree = true
+        ).assertHasClickAction()
+            .onChildren()
+            .assertAny(
+                hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_BUTTON_TEXT)
+                    .and(hasText("Waiting.."))
+            ).assertAny(
+                hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_INDICATOR)
+            )
+
+        // Update the state to disconnected with error
+        val error = AssuranceConstants.AssuranceConnectionError.UNEXPECTED_ERROR
+        quickConnectState.value = ConnectionState.Disconnected(error)
+        composeTestRule.waitForIdle()
+
+        // Verify that the QuickConnectErrorPanel is shown
+        val errorPanelContent = composeTestRule.onNodeWithTag(
+            AssuranceUiTestTags.QuickConnectScreen.CONNECTION_ERROR_PANEL,
+            useUnmergedTree = true
+        )
+            .assertExists()
+            .onChildren()
+
+        errorPanelContent.filterToOne(hasTestTag(AssuranceUiTestTags.QuickConnectScreen.CONNECTION_ERROR_TEXT))
+            .assertTextEquals(error.error)
+        errorPanelContent.filterToOne(hasTestTag(AssuranceUiTestTags.QuickConnectScreen.CONNECTION_ERROR_DESCRIPTION))
+            .assertTextEquals(error.description)
+
+        composeTestRule.onNodeWithTag(
+            AssuranceUiTestTags.QuickConnectScreen.PROGRESS_BUTTON,
+            useUnmergedTree = true
+        )
+            .onChildren()
+            .assertAny(
+                hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_BUTTON_TEXT).and(
+                    hasText(
+                        "Retry"
+                    )
+                )
+            ).assertAny(
+                !hasTestTag(AssuranceUiTestTags.QuickConnectScreen.PROGRESS_INDICATOR)
+            )
+
+        uiDevice.setOrientationNatural()
     }
 }

--- a/code/assurance/src/androidTest/java/com/adobe/marketing/mobile/assurance/internal/ui/status/AssuranceStatusScreenTests.kt
+++ b/code/assurance/src/androidTest/java/com/adobe/marketing/mobile/assurance/internal/ui/status/AssuranceStatusScreenTests.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.test.onChildren
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
 import com.adobe.marketing.mobile.MobileCore
 import com.adobe.marketing.mobile.assurance.internal.AssuranceComponentRegistry
 import com.adobe.marketing.mobile.assurance.internal.AssuranceConstants
@@ -92,6 +93,64 @@ class AssuranceStatusScreenTests {
     }
 
     @Test
+    fun testAssuranceStatusScreenInLandscapeMode() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val uiDevice = UiDevice.getInstance(instrumentation)
+        uiDevice.setOrientationLandscape()
+
+        // Setup
+        val testLog1 = "Test Log 1"
+        val testLog2 = "Test Log 2"
+
+        AssuranceComponentRegistry.appState.logStatus(AssuranceConstants.UILogColorVisibility.LOW, testLog1)
+        AssuranceComponentRegistry.appState.logStatus(AssuranceConstants.UILogColorVisibility.HIGH, testLog2)
+
+        composeTestRule.setContent {
+            AssuranceStatusScreen()
+        }
+
+        composeTestRule.waitForIdle()
+
+        // Verify
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.ASSURANCE_HEADER)
+            .assertExists()
+            .assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.StatusScreen.STATUS_CLOSE_BUTTON)
+            .assertExists()
+            .assertIsDisplayed()
+            .assertTextEquals("\u2715")
+
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.StatusScreen.STATUS_VIEW)
+            .assertExists()
+            .assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.StatusScreen.LOGS_PANEL)
+            .assertExists()
+            .assertIsDisplayed()
+
+        val logContent = composeTestRule.onNodeWithTag(AssuranceUiTestTags.StatusScreen.LOGS_CONTENT)
+            .assertExists()
+            .assertIsDisplayed()
+
+        logContent.onChildren().assertCountEquals(2)
+        val log1 = logContent.onChildren()[0]
+        log1.assertTextEquals(testLog1)
+        val log2 = logContent.onChildren()[1]
+        log2.assertTextEquals(testLog2)
+
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.StatusScreen.CLEAR_LOG_BUTTON)
+            .assertExists()
+            .assertTextEquals("Clear Log")
+
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.StatusScreen.STATUS_DISCONNECT_BUTTON)
+            .assertExists()
+            .assertTextEquals("Disconnect")
+
+        uiDevice.setOrientationNatural()
+    }
+
+    @Test
     fun testStatusScreen_OnNewLogs() {
         // Setup
         val testLog1 = "Test Log 1"
@@ -157,6 +216,80 @@ class AssuranceStatusScreenTests {
 
         val log4 = logContent.onChildren()[3]
         log4.assertTextEquals(testLog4)
+    }
+
+    @Test
+    fun testStatusScreen_OnNewLogsInLandscapeMode() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val uiDevice = UiDevice.getInstance(instrumentation)
+        uiDevice.setOrientationLandscape()
+
+        // Setup
+        val testLog1 = "Test Log 1"
+        val testLog2 = "Test Log 2"
+
+        AssuranceComponentRegistry.appState.logStatus(AssuranceConstants.UILogColorVisibility.LOW, testLog1)
+        AssuranceComponentRegistry.appState.logStatus(AssuranceConstants.UILogColorVisibility.HIGH, testLog2)
+
+        composeTestRule.setContent {
+            AssuranceStatusScreen()
+        }
+
+        composeTestRule.waitForIdle()
+
+        // Verify
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.ASSURANCE_HEADER)
+            .assertExists()
+            .assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.StatusScreen.STATUS_CLOSE_BUTTON)
+            .assertExists()
+            .assertIsDisplayed()
+            .assertTextEquals("\u2715")
+
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.StatusScreen.STATUS_VIEW)
+            .assertExists()
+            .assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.StatusScreen.LOGS_PANEL)
+            .assertExists()
+            .assertIsDisplayed()
+
+        val logContent = composeTestRule.onNodeWithTag(AssuranceUiTestTags.StatusScreen.LOGS_CONTENT)
+            .assertExists()
+            .assertIsDisplayed()
+
+        logContent.onChildren().assertCountEquals(2)
+        val log1 = logContent.onChildren()[0]
+        log1.assertTextEquals(testLog1)
+        val log2 = logContent.onChildren()[1]
+        log2.assertTextEquals(testLog2)
+
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.StatusScreen.CLEAR_LOG_BUTTON)
+            .assertExists()
+            .assertTextEquals("Clear Log")
+
+        composeTestRule.onNodeWithTag(AssuranceUiTestTags.StatusScreen.STATUS_DISCONNECT_BUTTON)
+            .assertExists()
+            .assertTextEquals("Disconnect")
+
+        // Add New Logs
+        val testLog3 = "Test Log 3"
+        val testLog4 = "Test Log 4"
+        AssuranceComponentRegistry.appState.logStatus(AssuranceConstants.UILogColorVisibility.LOW, testLog3)
+        AssuranceComponentRegistry.appState.logStatus(AssuranceConstants.UILogColorVisibility.HIGH, testLog4)
+
+        composeTestRule.waitForIdle()
+
+        // Verify
+        logContent.onChildren().assertCountEquals(4)
+        val log3 = logContent.onChildren()[2]
+        log3.assertTextEquals(testLog3)
+
+        val log4 = logContent.onChildren()[3]
+        log4.assertTextEquals(testLog4)
+
+        uiDevice.setOrientationNatural()
     }
 
     @Test

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/AssuranceSessionPresentationManager.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/AssuranceSessionPresentationManager.kt
@@ -176,6 +176,8 @@ internal class AssuranceSessionPresentationManager {
 
     private fun showAssuranceActivity(currentActivity: Activity?) {
         if (currentActivity == null) return
+        if (currentActivity is AssuranceActivity) return
+
         val intent = Intent(currentActivity, AssuranceActivity::class.java)
         intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
         intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/AssuranceActivity.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/AssuranceActivity.kt
@@ -11,7 +11,6 @@
 
 package com.adobe.marketing.mobile.assurance.internal.ui
 
-import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -20,7 +19,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
@@ -51,18 +49,6 @@ class AssuranceActivity : ComponentActivity() {
                                 .safeDrawingPadding()
                                 .fillMaxSize()
                         ) {
-
-                            // Locks the Assurance screen to always be in portrait mode.
-                            val orientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-                            DisposableEffect(orientation) {
-                                val originalOrientation = requestedOrientation
-                                requestedOrientation = orientation
-                                onDispose {
-                                    // restore original orientation when view disappears
-                                    requestedOrientation = originalOrientation
-                                }
-                            }
-
                             // Set the status bar and navigation bar colors to be the same as the
                             // background color of Assurance screens. This is to simulate an edge to edge
                             // experience while the Assurance UI is active.

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/AssuranceActivity.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/AssuranceActivity.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Alignment.Companion.TopCenter
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.navigation.compose.rememberNavController
@@ -35,6 +36,7 @@ class AssuranceActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         val connectionPhase = AssuranceComponentRegistry.appState.sessionPhase.value
+        val orientation = resources.configuration.orientation
 
         setContent {
             MaterialTheme(
@@ -47,7 +49,8 @@ class AssuranceActivity : ComponentActivity() {
                         Box(
                             modifier = Modifier
                                 .safeDrawingPadding()
-                                .fillMaxSize()
+                                .fillMaxSize(),
+                            contentAlignment = TopCenter
                         ) {
                             // Set the status bar and navigation bar colors to be the same as the
                             // background color of Assurance screens. This is to simulate an edge to edge

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/AssuranceActivity.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/AssuranceActivity.kt
@@ -36,7 +36,6 @@ class AssuranceActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         val connectionPhase = AssuranceComponentRegistry.appState.sessionPhase.value
-        val orientation = resources.configuration.orientation
 
         setContent {
             MaterialTheme(

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/AssuranceUiTestTags.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/AssuranceUiTestTags.kt
@@ -20,6 +20,7 @@ internal object AssuranceUiTestTags {
 
     internal object QuickConnectScreen {
         internal const val QUICK_CONNECT_VIEW = "quickConnectView"
+        internal const val QUICK_CONNECT_SCROLLVIEW = "quickConnectScrollView"
         internal const val QUICK_CONNECT_LOGO = "quickConnectLogo"
         internal const val ADOBE_LOGO = "adobeLogo"
 

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/PinScreen.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/PinScreen.kt
@@ -11,10 +11,8 @@
 
 package com.adobe.marketing.mobile.assurance.internal.ui.pin
 
-import android.content.pm.ActivityInfo
 import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.adobe.marketing.mobile.assurance.internal.AssuranceConstants.AssuranceEnvironment
@@ -39,17 +37,6 @@ internal fun PinScreen(sessionId: String, environment: AssuranceEnvironment) {
             environment = environment
         )
     )
-
-    // Locks the PIN screen to always be in portrait mode.
-    val orientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-    DisposableEffect(orientation) {
-        val originalOrientation = activity.requestedOrientation
-        activity.requestedOrientation = orientation
-        onDispose {
-            // restore original orientation when view disappears
-            activity.requestedOrientation = originalOrientation
-        }
-    }
 
     // Handle back button press
     BackHandler {

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/DialPadView.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/DialPadView.kt
@@ -60,7 +60,7 @@ internal fun DialPadView(
     Box(
         modifier = Modifier
             .fillMaxHeight()
-            // Set the width to a maximum of 600dp or the screen width, whichever is smaller
+            // Set the width to a minimum of 600dp or the screen width.
             // This is to ensure that the dial pad buttons are not too large on squarish aspect ratios
             .widthIn(max = min(600f, (width.toFloat())).dp)
             .verticalScroll(scrollState)

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/DialPadView.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/pin/dialpad/DialPadView.kt
@@ -16,18 +16,22 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import com.adobe.marketing.mobile.assurance.R
 import com.adobe.marketing.mobile.assurance.internal.ui.AssuranceUiTestTags
 import com.adobe.marketing.mobile.assurance.internal.ui.common.AssuranceHeader
@@ -36,6 +40,7 @@ import com.adobe.marketing.mobile.assurance.internal.ui.pin.PinScreenAction
 import com.adobe.marketing.mobile.assurance.internal.ui.pin.PinScreenState
 import com.adobe.marketing.mobile.assurance.internal.ui.theme.AssuranceTheme
 import com.adobe.marketing.mobile.assurance.internal.ui.theme.AssuranceTheme.backgroundColor
+import kotlin.math.min
 
 /**
  * DialPadView is the landing view for the Pin screen. It displays the pin feedback row,
@@ -50,17 +55,24 @@ internal fun DialPadView(
 ) {
 
     val scrollState = rememberScrollState()
+    val width = LocalConfiguration.current.screenWidthDp
+
     Box(
         modifier = Modifier
-            .fillMaxSize()
+            .fillMaxHeight()
+            // Set the width to a maximum of 600dp or the screen width, whichever is smaller
+            // This is to ensure that the dial pad buttons are not too large on squarish aspect ratios
+            .widthIn(max = min(600f, (width.toFloat())).dp)
             .verticalScroll(scrollState)
             .background(backgroundColor)
             .padding(horizontal = AssuranceTheme.dimensions.padding.xxLarge)
-            .testTag(AssuranceUiTestTags.PinScreen.DIAL_PAD_VIEW)
+            .testTag(AssuranceUiTestTags.PinScreen.DIAL_PAD_VIEW),
+
     ) {
         Column(
             modifier = Modifier.fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(AssuranceTheme.dimensions.spacing.medium)
+            verticalArrangement = Arrangement.spacedBy(AssuranceTheme.dimensions.spacing.medium),
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
             AssuranceHeader()
             AssuranceSubHeader(text = stringResource(id = R.string.pin_screen_header))

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectView.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/quickconnect/QuickConnectView.kt
@@ -11,20 +11,26 @@
 
 package com.adobe.marketing.mobile.assurance.internal.ui.quickconnect
 
+import android.content.res.Configuration
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -45,6 +51,14 @@ internal fun QuickConnectView(
     quickConnectState: State<ConnectionState>,
     onAction: (QuickConnectScreenAction) -> Unit
 ) {
+    val isTv = with(LocalConfiguration.current) {
+        remember { (this.uiMode and Configuration.UI_MODE_TYPE_MASK) == Configuration.UI_MODE_TYPE_TELEVISION }
+    }
+
+    val isLandscape = with(LocalConfiguration.current) {
+        remember { (this.orientation == Configuration.ORIENTATION_LANDSCAPE || this.orientation == Configuration.ORIENTATION_UNDEFINED) }
+    }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -54,7 +68,9 @@ internal fun QuickConnectView(
     ) {
         Column(
             modifier = Modifier
-                .fillMaxSize(),
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .testTag(AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_SCROLLVIEW),
             verticalArrangement = Arrangement.spacedBy(AssuranceTheme.dimensions.spacing.medium),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
@@ -67,11 +83,12 @@ internal fun QuickConnectView(
                 contentDescription = "Quick Connect Flow",
                 contentScale = ContentScale.FillWidth,
                 modifier = Modifier
-                    .fillMaxWidth()
                     .padding(
                         horizontal = AssuranceTheme.dimensions.padding.xLarge,
                         vertical = AssuranceTheme.dimensions.padding.medium
                     )
+                    // Restrict the image to a max of 1/3rd of the screen in landscape mode or TV mode
+                    .fillMaxWidth(fraction = if (isTv || isLandscape) 0.3f else 1f)
                     .testTag(AssuranceUiTestTags.QuickConnectScreen.QUICK_CONNECT_LOGO)
 
             )
@@ -88,22 +105,23 @@ internal fun QuickConnectView(
 
             // Action buttons for triggering the connection
             ActionButtonRow(quickConnectState = quickConnectState.value, onAction = onAction)
+
+            // Spacer to push the Adobe Logo at the bottom of the screen while being scrollable.
+            Spacer(modifier = Modifier.weight(1f))
+
+            Image(
+                painter = painterResource(id = R.drawable.img_adobelogo),
+                contentDescription = "Adobe Logo",
+                contentScale = ContentScale.Inside,
+                modifier = Modifier
+                    .height(20.dp)
+                    .fillMaxWidth()
+                    .padding(
+                        bottom = AssuranceTheme.dimensions.padding.xSmall
+                    )
+                    .testTag(AssuranceUiTestTags.QuickConnectScreen.ADOBE_LOGO)
+
+            )
         }
-
-        // Adobe Logo at the bottom of the screen
-        Image(
-            painter = painterResource(id = R.drawable.img_adobelogo),
-            contentDescription = "Adobe Logo",
-            contentScale = ContentScale.Inside,
-            modifier = Modifier
-                .height(20.dp)
-                .fillMaxWidth()
-                .align(Alignment.BottomCenter)
-                .padding(
-                    bottom = AssuranceTheme.dimensions.padding.xSmall
-                )
-                .testTag(AssuranceUiTestTags.QuickConnectScreen.ADOBE_LOGO)
-
-        )
     }
 }

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/status/AssuranceStatusScreen.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/status/AssuranceStatusScreen.kt
@@ -90,7 +90,7 @@ internal fun AssuranceStatusScreen() {
             verticalArrangement = Arrangement.Center,
             modifier = Modifier
                 .fillMaxWidth()
-                .fillMaxHeight(if (isTv || isLandscape) 0.8f else 0.9f)
+                .fillMaxHeight(if (isTv || isLandscape) 0.7f else 0.9f)
                 .background(AssuranceTheme.statusLogBackgroundColor)
                 .testTag(AssuranceUiTestTags.StatusScreen.LOGS_PANEL)
         ) {

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/status/AssuranceStatusScreen.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/status/AssuranceStatusScreen.kt
@@ -11,6 +11,7 @@
 
 package com.adobe.marketing.mobile.assurance.internal.ui.status
 
+import android.content.res.Configuration
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -39,6 +40,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -58,6 +60,13 @@ import com.adobe.marketing.mobile.assurance.internal.ui.theme.AssuranceTheme.bac
 @Composable
 internal fun AssuranceStatusScreen() {
     val activity = LocalContext.current.findActivity() ?: return
+    val isTv = with(LocalConfiguration.current) {
+        remember { (this.uiMode and Configuration.UI_MODE_TYPE_MASK) == Configuration.UI_MODE_TYPE_TELEVISION }
+    }
+    val isLandscape = with(LocalConfiguration.current) {
+        remember { (this.orientation == Configuration.ORIENTATION_LANDSCAPE || this.orientation == Configuration.ORIENTATION_UNDEFINED) }
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -77,12 +86,12 @@ internal fun AssuranceStatusScreen() {
             AssuranceComponentRegistry.appState.statusLogs
         }
 
-        Row(
-            horizontalArrangement = Arrangement.Center,
+        Column(
+            verticalArrangement = Arrangement.Center,
             modifier = Modifier
                 .fillMaxWidth()
-                .fillMaxHeight(0.9f)
-                .background(Color(4281743682))
+                .fillMaxHeight(if (isTv || isLandscape) 0.8f else 0.9f)
+                .background(AssuranceTheme.statusLogBackgroundColor)
                 .testTag(AssuranceUiTestTags.StatusScreen.LOGS_PANEL)
         ) {
             // Lazy column to display the logs

--- a/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/theme/AssuranceTheme.kt
+++ b/code/assurance/src/main/java/com/adobe/marketing/mobile/assurance/internal/ui/theme/AssuranceTheme.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.dp
 
 internal object AssuranceTheme {
     internal val backgroundColor = Color(0xFF1C1F28)
+    internal val statusLogBackgroundColor = Color(4281743682)
     internal val dimensions = Dimensions
     internal val typography = Fonts
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Assurance SDK currently locks the device orientation to portrait mode when Assurance screens are active. This is done via 
`activity.setReequestedOrientation()` calls. From Android 16, orientation restrictions are no honored on devices running Android 16 when the app targets API 36. 

This PR has changes to ensure that the Assurance screens are usable in landscape mode. Note that no new UI is being built specifically for Landscape mode. Given the debug nature of the Assurance screens its primary use continues to be in portrait mode on mobile devices. Existing screens are being adapted to horizontal orientation. These changes will also be usable for Assurance TV support.

Key Changes:
- Restrict the width of PinScreen in landscape and TV modes. Pin Authorization flow is not recommended for TV, however it is being taken care of for completeness.
- Ensure that the images on the QuickConnect screen are limited to 1/3rd  of the screen width in TV and landscape mode.
- Status screen log view is limited to 70% of the height in landscape mode to ensure the action buttons are legible and visible.
- Add instrumentation tests for screens with new orientation changes.
- Make a small optimization in preventing launching the Assurance activity when it is already the current one.


<!--- Describe your changes in detail -->

## Related Issue

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- Manual tests on TV, Phone, Tablet
- New and existing instrumentation tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.