### PR TITLE
Update Android workflows to `gha-android-3.4.1`

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -31,15 +31,24 @@ on:
         type: string
         required: true
 
+      ref:
+        description: |
+          The git reference (branch, tag, or SHA) to check out when publishing the release.
+          Defaults to 'main'.
+        required: false
+        type: string
+        default: 'main'
+
 jobs:
   publish:
     permissions:
         contents: write
-    uses: adobe/aepsdk-commons/.github/workflows/android-maven-release.yml@gha-android-3.4.0
+    uses: adobe/aepsdk-commons/.github/workflows/android-maven-release.yml@gha-android-3.4.1
     with:
       tag: ${{ github.event.inputs.tag }}
       create-github-release: ${{ github.event.inputs.create-github-release == 'true' }}
       version-validation-paths: code/gradle.properties, code/assurance/src/main/java/com/adobe/marketing/mobile/Assurance.java
       version-validation-dependencies: Core ${{ github.event.inputs.core-dependency }}
       staging-dir: code/assurance/build/staging-deploy
+      ref: ${{ github.event.inputs.ref }}
     secrets: inherit

--- a/.github/workflows/maven-snapshot.yml
+++ b/.github/workflows/maven-snapshot.yml
@@ -16,15 +16,15 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: "Git reference (branch, tag, or SHA) to check out when publishing the snapshot. Defaults to 'main'."
+        description: "Git reference (branch, tag, or SHA) to check out when publishing the snapshot. Defaults to 'staging'."
         required: false
-        default: "main"
+        default: "staging"
 
 jobs:
   publish:
     permissions:
         contents: write
-    uses: adobe/aepsdk-commons/.github/workflows/android-maven-snapshot.yml@gha-android-3.4.0
+    uses: adobe/aepsdk-commons/.github/workflows/android-maven-snapshot.yml@gha-android-3.4.1
     secrets: inherit
     with:
       ref: ${{ inputs.ref }}

--- a/.github/workflows/maven-snapshot.yml
+++ b/.github/workflows/maven-snapshot.yml
@@ -18,7 +18,7 @@ on:
       ref:
         description: "Git reference (branch, tag, or SHA) to check out when publishing the snapshot. Defaults to 'staging'."
         required: false
-        default: "staging"
+        default: 'staging'
 
 jobs:
   publish:

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -38,7 +38,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: adobe/aepsdk-commons/.github/workflows/versions.yml@gha-android-3.3.0
+    uses: adobe/aepsdk-commons/.github/workflows/versions.yml@gha-android-3.4.1
     with:
       version: ${{ github.event.inputs.version }}
       branch: ${{ github.event.inputs.branch }}


### PR DESCRIPTION

## Description

This PR updates: 
* The 3.x branch to be able to use the new `ref` param available in the Maven release workflow
* Updates snapshot workflow to use `staging` branch as default (instead of `main`)
* Upgrades version update workflow to use latest `gha-android-3.4.1` tag

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.